### PR TITLE
fix(release): publish packages to GitHub Packages under repo owner scope

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,36 @@
+name: Publish GitHub Packages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          registry-url: https://npm.pkg.github.com
+          scope: '@graph-render'
+
+      - name: Install dependencies
+        run: HUSKY=0 yarn install --frozen-lockfile
+
+      - name: Build all packages
+        run: yarn build
+
+      - name: Publish packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: node scripts/publish-github-packages.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     # Prevent running on the version-bump commit that semantic-release itself pushes
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')
     permissions:
       contents: write
       packages: write
@@ -61,7 +61,15 @@ jobs:
           -p @semantic-release/release-notes-generator@14.0.0
           multi-semantic-release
 
+      - name: Setup Node.js for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: https://npm.pkg.github.com
+          scope: '@graph-render'
+
       - name: Publish to GitHub Packages
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: node scripts/publish-github-packages.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ tmp/
 
 # Ephemeral auth config created by scripts/publish-github-packages.mjs
 **/.npmrc.publish
+**/*.gpr-backup

--- a/README.md
+++ b/README.md
@@ -147,19 +147,23 @@ On every push to `main` or `master` (with a [Conventional Commit](https://www.co
 
 - **GitHub Releases** — one release per published package (`@graph-render/types`, `core`, `react`, `tournament-tree`)
 - **npm** — published to [npmjs.com](https://www.npmjs.com/org/graph-render) when `NPM_TOKEN` is configured in repo secrets
-- **GitHub Packages** — the same versions are published to `https://npm.pkg.github.com`
+- **GitHub Packages** — the same versions are published to `https://npm.pkg.github.com` (see note on scope below)
 
-Install from GitHub Packages:
+Install from GitHub Packages (personal repo — packages use the GitHub owner as scope):
 
 ```bash
 # ~/.npmrc
-@graph-render:registry=https://npm.pkg.github.com
+@oleksandr-zhynzher:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN
 ```
 
 ```bash
-yarn add @graph-render/tournament-tree
+yarn add @oleksandr-zhynzher/tournament-tree
 ```
+
+> **Scope note:** npm packages stay `@graph-render/*` on [npmjs.com](https://www.npmjs.com/org/graph-render). On GitHub Packages they are published as `@<github-owner>/*` (e.g. `@oleksandr-zhynzher/tournament-tree`) because GitHub requires the scope to match the repository owner. To use `@graph-render/*` on GitHub Packages, move the repo under a [GitHub organization](https://github.com/graph-render) named `graph-render`.
+
+To backfill packages without a new release, run the **Publish GitHub Packages** workflow under Actions.
 
 Storybook is deployed to GitHub Pages on the same branches via the **Deploy Storybook** workflow.
 

--- a/scripts/publish-github-packages.mjs
+++ b/scripts/publish-github-packages.mjs
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REGISTRY = 'https://npm.pkg.github.com';
@@ -10,17 +10,47 @@ if (!token) {
   process.exit(1);
 }
 
+const repository = process.env.GITHUB_REPOSITORY ?? '';
+const repositoryOwner = repository.split('/')[0] ?? process.env.GITHUB_REPOSITORY_OWNER ?? '';
+
+if (!repositoryOwner) {
+  console.error('GITHUB_REPOSITORY or GITHUB_REPOSITORY_OWNER is required.');
+  process.exit(1);
+}
+
 const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const workspaceDirs = rootPkg.workspaces ?? [];
 
 const npmrcContents = [
   `@graph-render:registry=${REGISTRY}`,
+  `@${repositoryOwner}:registry=${REGISTRY}`,
   `//npm.pkg.github.com/:_authToken=${token}`,
   'always-auth=true',
 ].join('\n');
 
+const scopedNamePattern = /^@([^/]+)\/(.+)$/;
+
+const resolveGithubPackageName = (packageName) => {
+  const match = scopedNamePattern.exec(packageName);
+  if (!match) {
+    return packageName;
+  }
+
+  const [, scope, shortName] = match;
+  if (scope.toLowerCase() === repositoryOwner.toLowerCase()) {
+    return packageName;
+  }
+
+  const githubName = `@${repositoryOwner}/${shortName}`;
+  console.log(
+    `  scope @${scope} does not match GitHub owner ${repositoryOwner}; publishing as ${githubName}`
+  );
+  return githubName;
+};
+
 let published = 0;
 let skipped = 0;
+let failed = 0;
 
 for (const dir of workspaceDirs) {
   const packageJsonPath = join(dir, 'package.json');
@@ -30,33 +60,61 @@ for (const dir of workspaceDirs) {
     continue;
   }
 
+  const distEntry = pkg.main ?? pkg.module;
+  if (distEntry) {
+    const distPath = join(dir, distEntry);
+    if (!existsSync(distPath)) {
+      console.error(`\n→ ${pkg.name}@${pkg.version}`);
+      console.error(`  missing build output: ${distPath}`);
+      failed += 1;
+      continue;
+    }
+  }
+
+  const publishName = resolveGithubPackageName(pkg.name);
   const npmrcPath = join(dir, '.npmrc.publish');
+  const backupPath = `${packageJsonPath}.gpr-backup`;
+  const needsNamePatch = publishName !== pkg.name;
+
   writeFileSync(npmrcPath, `${npmrcContents}\n`);
 
-  console.log(`\n→ ${pkg.name}@${pkg.version}`);
+  if (needsNamePatch) {
+    writeFileSync(backupPath, readFileSync(packageJsonPath, 'utf8'));
+    writeFileSync(packageJsonPath, `${JSON.stringify({ ...pkg, name: publishName }, null, 2)}\n`);
+  }
+
+  console.log(`\n→ ${publishName}@${pkg.version}`);
 
   try {
-    execSync('npm publish --access public', {
+    execSync(`npm publish --registry ${REGISTRY} --access public`, {
       cwd: dir,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        npm_config_registry: REGISTRY,
         npm_config_userconfig: npmrcPath,
       },
     });
     published += 1;
   } catch (error) {
     const output = `${error.stdout ?? ''}${error.stderr ?? ''}${error.message ?? ''}`;
-    console.log(output.trim());
+    if (output.trim()) {
+      console.log(output.trim());
+    }
+
     if (/E409|409|already exists|cannot publish.*version/i.test(output)) {
-      console.log(`  skipped (version already on GitHub Packages)`);
+      console.log('  skipped (version already on GitHub Packages)');
       skipped += 1;
     } else {
-      unlinkSync(npmrcPath);
-      throw error;
+      failed += 1;
     }
   } finally {
+    if (needsNamePatch && existsSync(backupPath)) {
+      writeFileSync(packageJsonPath, readFileSync(backupPath, 'utf8'));
+      unlinkSync(backupPath);
+    }
+
     try {
       unlinkSync(npmrcPath);
     } catch {
@@ -65,4 +123,13 @@ for (const dir of workspaceDirs) {
   }
 }
 
-console.log(`\nGitHub Packages: ${published} published, ${skipped} skipped.`);
+console.log(`\nGitHub Packages: ${published} published, ${skipped} skipped, ${failed} failed.`);
+
+if (failed > 0) {
+  process.exit(1);
+}
+
+if (published === 0 && skipped === 0) {
+  console.error('No packages were published. Check workspace configuration and build outputs.');
+  process.exit(1);
+}

--- a/src/core-graph-render/CHANGELOG.md
+++ b/src/core-graph-render/CHANGELOG.md
@@ -1,19 +1,15 @@
 ## @graph-render/core 1.3.0 (2026-05-17)
 
-* feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
-* docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
-* refactor: graph rendering components ([35afb51](https://github.com/oleksandr-zhynzher/graph-render/commit/35afb51))
-* refactor: move inline constants to constants files ([7fcaaa6](https://github.com/oleksandr-zhynzher/graph-render/commit/7fcaaa6))
-* refactor: replace all hardcoded string literal types with enums ([65f5a6e](https://github.com/oleksandr-zhynzher/graph-render/commit/65f5a6e))
-* style: apply prettier formatting to changelogs ([f245bfe](https://github.com/oleksandr-zhynzher/graph-render/commit/f245bfe))
-
-
-
-
+- feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
+- docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
+- refactor: graph rendering components ([35afb51](https://github.com/oleksandr-zhynzher/graph-render/commit/35afb51))
+- refactor: move inline constants to constants files ([7fcaaa6](https://github.com/oleksandr-zhynzher/graph-render/commit/7fcaaa6))
+- refactor: replace all hardcoded string literal types with enums ([65f5a6e](https://github.com/oleksandr-zhynzher/graph-render/commit/65f5a6e))
+- style: apply prettier formatting to changelogs ([f245bfe](https://github.com/oleksandr-zhynzher/graph-render/commit/f245bfe))
 
 ### Dependencies
 
-* **@graph-render/types:** upgraded to 1.2.0
+- **@graph-render/types:** upgraded to 1.2.0
 
 ## @graph-render/core [1.2.1](https://github.com/oleksandr-zhynzher/graph-render/compare/@graph-render/core@1.2.0...@graph-render/core@1.2.1) (2026-05-13)
 

--- a/src/react-graph-render/CHANGELOG.md
+++ b/src/react-graph-render/CHANGELOG.md
@@ -1,20 +1,16 @@
 ## @graph-render/react 1.4.0 (2026-05-17)
 
-* feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
-* docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
-* refactor: graph rendering components ([35afb51](https://github.com/oleksandr-zhynzher/graph-render/commit/35afb51))
-* refactor: move inline constants to constants files ([7fcaaa6](https://github.com/oleksandr-zhynzher/graph-render/commit/7fcaaa6))
-* refactor: replace all hardcoded string literal types with enums ([65f5a6e](https://github.com/oleksandr-zhynzher/graph-render/commit/65f5a6e))
-* style: apply prettier formatting to changelogs ([f245bfe](https://github.com/oleksandr-zhynzher/graph-render/commit/f245bfe))
-
-
-
-
+- feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
+- docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
+- refactor: graph rendering components ([35afb51](https://github.com/oleksandr-zhynzher/graph-render/commit/35afb51))
+- refactor: move inline constants to constants files ([7fcaaa6](https://github.com/oleksandr-zhynzher/graph-render/commit/7fcaaa6))
+- refactor: replace all hardcoded string literal types with enums ([65f5a6e](https://github.com/oleksandr-zhynzher/graph-render/commit/65f5a6e))
+- style: apply prettier formatting to changelogs ([f245bfe](https://github.com/oleksandr-zhynzher/graph-render/commit/f245bfe))
 
 ### Dependencies
 
-* **@graph-render/core:** upgraded to 1.3.0
-* **@graph-render/types:** upgraded to 1.2.0
+- **@graph-render/core:** upgraded to 1.3.0
+- **@graph-render/types:** upgraded to 1.2.0
 
 ## @graph-render/react [1.3.0](https://github.com/oleksandr-zhynzher/graph-render/compare/@graph-render/react@1.2.0...@graph-render/react@1.3.0) (2026-05-13)
 

--- a/src/react-tournament-tree/CHANGELOG.md
+++ b/src/react-tournament-tree/CHANGELOG.md
@@ -1,16 +1,12 @@
 ## @graph-render/tournament-tree 1.5.0 (2026-05-17)
 
-* feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
-* docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
-
-
-
-
+- feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
+- docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
 
 ### Dependencies
 
-* **@graph-render/react:** upgraded to 1.4.0
-* **@graph-render/types:** upgraded to 1.2.0
+- **@graph-render/react:** upgraded to 1.4.0
+- **@graph-render/types:** upgraded to 1.2.0
 
 ## @graph-render/tournament-tree [1.4.0](https://github.com/oleksandr-zhynzher/graph-render/compare/@graph-render/tournament-tree@1.3.0...@graph-render/tournament-tree@1.4.0) (2026-05-16)
 

--- a/src/types/CHANGELOG.md
+++ b/src/types/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## @graph-render/types 1.2.0 (2026-05-17)
 
-* feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
-* docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
-* refactor: graph rendering components ([35afb51](https://github.com/oleksandr-zhynzher/graph-render/commit/35afb51))
-* refactor: replace all hardcoded string literal types with enums ([65f5a6e](https://github.com/oleksandr-zhynzher/graph-render/commit/65f5a6e))
-* style: apply prettier formatting to changelogs ([f245bfe](https://github.com/oleksandr-zhynzher/graph-render/commit/f245bfe))
+- feat(tournament-tree): add configurable bracket appearance API (#10) ([b9e8adc](https://github.com/oleksandr-zhynzher/graph-render/commit/b9e8adc)), closes [#10](https://github.com/oleksandr-zhynzher/graph-render/issues/10)
+- docs: refocus READMEs on adopters and quick starts ([a8309aa](https://github.com/oleksandr-zhynzher/graph-render/commit/a8309aa))
+- refactor: graph rendering components ([35afb51](https://github.com/oleksandr-zhynzher/graph-render/commit/35afb51))
+- refactor: replace all hardcoded string literal types with enums ([65f5a6e](https://github.com/oleksandr-zhynzher/graph-render/commit/65f5a6e))
+- style: apply prettier formatting to changelogs ([f245bfe](https://github.com/oleksandr-zhynzher/graph-render/commit/f245bfe))
 
 ## @graph-render/types [1.1.0](https://github.com/oleksandr-zhynzher/graph-render/compare/@graph-render/types@1.0.2...@graph-render/types@1.1.0) (2026-05-13)
 


### PR DESCRIPTION
Force the GitHub registry during npm publish, remap @graph-render/* to @<github-owner>/* when scopes differ, add a manual publish workflow, and use GH_TOKEN with packages:write for authentication.