### PR TITLE
fix(release): publish @graph-render packages without scope remapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,3 @@ tmp/
 
 # Ephemeral auth config created by scripts/publish-github-packages.mjs
 **/.npmrc.publish
-**/*.gpr-backup

--- a/README.md
+++ b/README.md
@@ -147,21 +147,28 @@ On every push to `main` or `master` (with a [Conventional Commit](https://www.co
 
 - **GitHub Releases** — one release per published package (`@graph-render/types`, `core`, `react`, `tournament-tree`)
 - **npm** — published to [npmjs.com](https://www.npmjs.com/org/graph-render) when `NPM_TOKEN` is configured in repo secrets
-- **GitHub Packages** — the same versions are published to `https://npm.pkg.github.com` (see note on scope below)
+- **GitHub Packages** — the same versions under `@graph-render/*` on `https://npm.pkg.github.com`
 
-Install from GitHub Packages (personal repo — packages use the GitHub owner as scope):
+Published packages:
+
+| Package                         | Description               |
+| ------------------------------- | ------------------------- |
+| `@graph-render/types`           | Shared TypeScript types   |
+| `@graph-render/core`            | Layout and routing engine |
+| `@graph-render/react`           | Interactive graph canvas  |
+| `@graph-render/tournament-tree` | Tournament bracket UI     |
+
+Install from GitHub Packages:
 
 ```bash
 # ~/.npmrc
-@oleksandr-zhynzher:registry=https://npm.pkg.github.com
+@graph-render:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN
 ```
 
 ```bash
-yarn add @oleksandr-zhynzher/tournament-tree
+yarn add @graph-render/tournament-tree
 ```
-
-> **Scope note:** npm packages stay `@graph-render/*` on [npmjs.com](https://www.npmjs.com/org/graph-render). On GitHub Packages they are published as `@<github-owner>/*` (e.g. `@oleksandr-zhynzher/tournament-tree`) because GitHub requires the scope to match the repository owner. To use `@graph-render/*` on GitHub Packages, move the repo under a [GitHub organization](https://github.com/graph-render) named `graph-render`.
 
 To backfill packages without a new release, run the **Publish GitHub Packages** workflow under Actions.
 

--- a/scripts/publish-github-packages.mjs
+++ b/scripts/publish-github-packages.mjs
@@ -10,43 +10,14 @@ if (!token) {
   process.exit(1);
 }
 
-const repository = process.env.GITHUB_REPOSITORY ?? '';
-const repositoryOwner = repository.split('/')[0] ?? process.env.GITHUB_REPOSITORY_OWNER ?? '';
-
-if (!repositoryOwner) {
-  console.error('GITHUB_REPOSITORY or GITHUB_REPOSITORY_OWNER is required.');
-  process.exit(1);
-}
-
 const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const workspaceDirs = rootPkg.workspaces ?? [];
 
 const npmrcContents = [
-  `@graph-render:registry=${REGISTRY}`,
-  `@${repositoryOwner}:registry=${REGISTRY}`,
+  '@graph-render:registry=https://npm.pkg.github.com',
   `//npm.pkg.github.com/:_authToken=${token}`,
   'always-auth=true',
 ].join('\n');
-
-const scopedNamePattern = /^@([^/]+)\/(.+)$/;
-
-const resolveGithubPackageName = (packageName) => {
-  const match = scopedNamePattern.exec(packageName);
-  if (!match) {
-    return packageName;
-  }
-
-  const [, scope, shortName] = match;
-  if (scope.toLowerCase() === repositoryOwner.toLowerCase()) {
-    return packageName;
-  }
-
-  const githubName = `@${repositoryOwner}/${shortName}`;
-  console.log(
-    `  scope @${scope} does not match GitHub owner ${repositoryOwner}; publishing as ${githubName}`
-  );
-  return githubName;
-};
 
 let published = 0;
 let skipped = 0;
@@ -71,19 +42,10 @@ for (const dir of workspaceDirs) {
     }
   }
 
-  const publishName = resolveGithubPackageName(pkg.name);
   const npmrcPath = join(dir, '.npmrc.publish');
-  const backupPath = `${packageJsonPath}.gpr-backup`;
-  const needsNamePatch = publishName !== pkg.name;
-
   writeFileSync(npmrcPath, `${npmrcContents}\n`);
 
-  if (needsNamePatch) {
-    writeFileSync(backupPath, readFileSync(packageJsonPath, 'utf8'));
-    writeFileSync(packageJsonPath, `${JSON.stringify({ ...pkg, name: publishName }, null, 2)}\n`);
-  }
-
-  console.log(`\n→ ${publishName}@${pkg.version}`);
+  console.log(`\n→ ${pkg.name}@${pkg.version}`);
 
   try {
     execSync(`npm publish --registry ${REGISTRY} --access public`, {
@@ -110,11 +72,6 @@ for (const dir of workspaceDirs) {
       failed += 1;
     }
   } finally {
-    if (needsNamePatch && existsSync(backupPath)) {
-      writeFileSync(packageJsonPath, readFileSync(backupPath, 'utf8'));
-      unlinkSync(backupPath);
-    }
-
     try {
       unlinkSync(npmrcPath);
     } catch {

--- a/src/core-graph-render/CHANGELOG.md
+++ b/src/core-graph-render/CHANGELOG.md
@@ -1,14 +1,10 @@
 ## <small>1.3.1 (2026-05-17)</small>
 
-* fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
-
-
-
-
+- fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
 
 ### Dependencies
 
-* **@graph-render/types:** upgraded to 1.2.1
+- **@graph-render/types:** upgraded to 1.2.1
 
 ## @graph-render/core 1.3.0 (2026-05-17)
 

--- a/src/react-graph-render/CHANGELOG.md
+++ b/src/react-graph-render/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## <small>1.4.1 (2026-05-17)</small>
 
-* fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
-
-
-
-
+- fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
 
 ### Dependencies
 
-* **@graph-render/core:** upgraded to 1.3.1
-* **@graph-render/types:** upgraded to 1.2.1
+- **@graph-render/core:** upgraded to 1.3.1
+- **@graph-render/types:** upgraded to 1.2.1
 
 ## @graph-render/react 1.4.0 (2026-05-17)
 

--- a/src/react-tournament-tree/CHANGELOG.md
+++ b/src/react-tournament-tree/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## <small>1.5.1 (2026-05-17)</small>
 
-* fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
-
-
-
-
+- fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
 
 ### Dependencies
 
-* **@graph-render/react:** upgraded to 1.4.1
-* **@graph-render/types:** upgraded to 1.2.1
+- **@graph-render/react:** upgraded to 1.4.1
+- **@graph-render/types:** upgraded to 1.2.1
 
 ## @graph-render/tournament-tree 1.5.0 (2026-05-17)
 

--- a/src/types/CHANGELOG.md
+++ b/src/types/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## <small>1.2.1 (2026-05-17)</small>
 
-* fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
+- fix(release): publish packages to GitHub Packages under repo owner scope (#11) ([98c8d69](https://github.com/oleksandr-zhynzher/graph-render/commit/98c8d69)), closes [#11](https://github.com/oleksandr-zhynzher/graph-render/issues/11)
 
 ## @graph-render/types 1.2.0 (2026-05-17)
 


### PR DESCRIPTION
GitHub Packages already hosts @graph-render/types, core, react, and tournament-tree. Publish those names directly and document the correct install instructions in the README.