### PR TITLE
fix(release): force @graph-render scope when publishing to GitHub Pac…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ tmp/
 
 # Ephemeral auth config created by scripts/publish-github-packages.mjs
 **/.npmrc.publish
+**/*.gpr-backup

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ yarn add @graph-render/tournament-tree
 
 To backfill packages without a new release, run the **Publish GitHub Packages** workflow under Actions.
 
+If you see short names (`react`, `core`, `types`, `tournament-tree`) without the `@graph-render/` scope, those are stale packages from an earlier publish. Delete them under **Packages → Package settings → Delete package**, then re-run the publish workflow so only `@graph-render/*` packages remain.
+
 Storybook is deployed to GitHub Pages on the same branches via the **Deploy Storybook** workflow.
 
 ---

--- a/scripts/publish-github-packages.mjs
+++ b/scripts/publish-github-packages.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REGISTRY = 'https://npm.pkg.github.com';
+const EXPECTED_SCOPE = '@graph-render';
 const token = process.env.GITHUB_TOKEN ?? process.env.NODE_AUTH_TOKEN;
 
 if (!token) {
@@ -14,7 +15,7 @@ const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const workspaceDirs = rootPkg.workspaces ?? [];
 
 const npmrcContents = [
-  '@graph-render:registry=https://npm.pkg.github.com',
+  `${EXPECTED_SCOPE}:registry=${REGISTRY}`,
   `//npm.pkg.github.com/:_authToken=${token}`,
   'always-auth=true',
 ].join('\n');
@@ -25,9 +26,17 @@ let failed = 0;
 
 for (const dir of workspaceDirs) {
   const packageJsonPath = join(dir, 'package.json');
-  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const originalContents = readFileSync(packageJsonPath, 'utf8');
+  const pkg = JSON.parse(originalContents);
 
   if (pkg.private === true) {
+    continue;
+  }
+
+  if (!pkg.name?.startsWith(`${EXPECTED_SCOPE}/`)) {
+    console.error(`\n→ ${pkg.name ?? dir}`);
+    console.error(`  expected name to start with ${EXPECTED_SCOPE}/`);
+    failed += 1;
     continue;
   }
 
@@ -43,7 +52,21 @@ for (const dir of workspaceDirs) {
   }
 
   const npmrcPath = join(dir, '.npmrc.publish');
+  const backupPath = `${packageJsonPath}.gpr-backup`;
+
+  // package.json publishConfig.registry points at npmjs for semantic-release; override for GPR.
+  const publishPkg = {
+    ...pkg,
+    publishConfig: {
+      ...pkg.publishConfig,
+      access: 'public',
+      registry: REGISTRY,
+    },
+  };
+
   writeFileSync(npmrcPath, `${npmrcContents}\n`);
+  writeFileSync(backupPath, originalContents);
+  writeFileSync(packageJsonPath, `${JSON.stringify(publishPkg, null, 2)}\n`);
 
   console.log(`\n→ ${pkg.name}@${pkg.version}`);
 
@@ -72,6 +95,9 @@ for (const dir of workspaceDirs) {
       failed += 1;
     }
   } finally {
+    writeFileSync(packageJsonPath, readFileSync(backupPath, 'utf8'));
+    unlinkSync(backupPath);
+
     try {
       unlinkSync(npmrcPath);
     } catch {

--- a/src/core-graph-render/CHANGELOG.md
+++ b/src/core-graph-render/CHANGELOG.md
@@ -1,14 +1,10 @@
 ## <small>1.3.2 (2026-05-17)</small>
 
-* fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
-
-
-
-
+- fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
 
 ### Dependencies
 
-* **@graph-render/types:** upgraded to 1.2.2
+- **@graph-render/types:** upgraded to 1.2.2
 
 ## <small>1.3.1 (2026-05-17)</small>
 

--- a/src/react-graph-render/CHANGELOG.md
+++ b/src/react-graph-render/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## <small>1.4.2 (2026-05-17)</small>
 
-* fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
-
-
-
-
+- fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
 
 ### Dependencies
 
-* **@graph-render/core:** upgraded to 1.3.2
-* **@graph-render/types:** upgraded to 1.2.2
+- **@graph-render/core:** upgraded to 1.3.2
+- **@graph-render/types:** upgraded to 1.2.2
 
 ## <small>1.4.1 (2026-05-17)</small>
 

--- a/src/react-tournament-tree/CHANGELOG.md
+++ b/src/react-tournament-tree/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## <small>1.5.2 (2026-05-17)</small>
 
-* fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
-
-
-
-
+- fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
 
 ### Dependencies
 
-* **@graph-render/react:** upgraded to 1.4.2
-* **@graph-render/types:** upgraded to 1.2.2
+- **@graph-render/react:** upgraded to 1.4.2
+- **@graph-render/types:** upgraded to 1.2.2
 
 ## <small>1.5.1 (2026-05-17)</small>
 

--- a/src/types/CHANGELOG.md
+++ b/src/types/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## <small>1.2.2 (2026-05-17)</small>
 
-* fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
+- fix(release): publish @graph-render packages without scope remapping (#12) ([19b35c6](https://github.com/oleksandr-zhynzher/graph-render/commit/19b35c6)), closes [#12](https://github.com/oleksandr-zhynzher/graph-render/issues/12)
 
 ## <small>1.2.1 (2026-05-17)</small>
 


### PR DESCRIPTION
…kages

Override publishConfig.registry to npm.pkg.github.com during GPR publish so packages are registered as @graph-render/*, not short owner-scoped names.