### PR TITLE
docs(ci): clarify GitHub Packages sidebar names and format changelogs in CI

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build all packages
         run: yarn build
 
+      - name: Format changelogs
+        run: yarn prettier --write 'src/**/CHANGELOG.md'
+
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
           -p @semantic-release/release-notes-generator@14.0.0
           multi-semantic-release
 
+      - name: Format changelogs
+        run: yarn prettier --write 'src/**/CHANGELOG.md'
+
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,11 @@ yarn add @graph-render/tournament-tree
 
 To backfill packages without a new release, run the **Publish GitHub Packages** workflow under Actions.
 
-If you see short names (`react`, `core`, `types`, `tournament-tree`) without the `@graph-render/` scope, those are stale packages from an earlier publish. Delete them under **Packages → Package settings → Delete package**, then re-run the publish workflow so only `@graph-render/*` packages remain.
+### Repo sidebar vs full package name
+
+On the repository home page, the **Packages** box often lists only the **basename** of a scoped package (`tournament-tree`, `react`, `core`, `types`). That is normal GitHub UI for `@scope/name` packages — the real name is still `@graph-render/tournament-tree`, `@graph-render/react`, and so on. Open **Packages** (or your [profile packages tab](https://github.com/oleksandr-zhynzher?tab=packages)) to confirm the full scoped name and version.
+
+If you still see **duplicate** packages (short names that are _not_ linked to `@graph-render/*`, or old versions you do not use), delete the stale entry: **Package → Package settings → Delete package**, then re-run **Publish GitHub Packages**.
 
 Storybook is deployed to GitHub Pages on the same branches via the **Deploy Storybook** workflow.
 

--- a/src/core-graph-render/CHANGELOG.md
+++ b/src/core-graph-render/CHANGELOG.md
@@ -1,14 +1,10 @@
 ## <small>1.3.3 (2026-05-17)</small>
 
-* fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
-
-
-
-
+- fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
 
 ### Dependencies
 
-* **@graph-render/types:** upgraded to 1.2.3
+- **@graph-render/types:** upgraded to 1.2.3
 
 ## <small>1.3.2 (2026-05-17)</small>
 

--- a/src/react-graph-render/CHANGELOG.md
+++ b/src/react-graph-render/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## <small>1.4.3 (2026-05-17)</small>
 
-* fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
-
-
-
-
+- fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
 
 ### Dependencies
 
-* **@graph-render/core:** upgraded to 1.3.3
-* **@graph-render/types:** upgraded to 1.2.3
+- **@graph-render/core:** upgraded to 1.3.3
+- **@graph-render/types:** upgraded to 1.2.3
 
 ## <small>1.4.2 (2026-05-17)</small>
 

--- a/src/react-tournament-tree/CHANGELOG.md
+++ b/src/react-tournament-tree/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## <small>1.5.3 (2026-05-17)</small>
 
-* fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
-
-
-
-
+- fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
 
 ### Dependencies
 
-* **@graph-render/react:** upgraded to 1.4.3
-* **@graph-render/types:** upgraded to 1.2.3
+- **@graph-render/react:** upgraded to 1.4.3
+- **@graph-render/types:** upgraded to 1.2.3
 
 ## <small>1.5.2 (2026-05-17)</small>
 

--- a/src/types/CHANGELOG.md
+++ b/src/types/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## <small>1.2.3 (2026-05-17)</small>
 
-* fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
+- fix(release): force @graph-render scope when publishing to GitHub Pac… (#13) ([841e4bf](https://github.com/oleksandr-zhynzher/graph-render/commit/841e4bf)), closes [#13](https://github.com/oleksandr-zhynzher/graph-render/issues/13)
 
 ## <small>1.2.2 (2026-05-17)</small>
 


### PR DESCRIPTION
… 

Explain that the repo sidebar shows scoped package basenames while the full name remains @graph-render/*. Run Prettier on package CHANGELOGs before GitHub Packages publish in release and manual workflows.