### PR TITLE
chore: enterprise architecture review fixes

### DIFF
--- a/src/core-graph-render/src/index.ts
+++ b/src/core-graph-render/src/index.ts
@@ -2,8 +2,10 @@ export { buildEdgePath, routeEdges, segmentIntersectsRect } from './edges';
 export {
   centeredLayout,
   compactBracketLayout,
+  createForceLayoutCache,
   dagLayout,
   forceDirectedLayout,
+  type ForceLayoutCache,
   gridLayout,
   layoutNodes,
   orthogonalFlowLayout,

--- a/src/core-graph-render/src/layouts/centered.ts
+++ b/src/core-graph-render/src/layouts/centered.ts
@@ -1,4 +1,9 @@
-import type { NodeData, Point, PositionedNode } from '@graph-render/types';
+import {
+  isPositionedNode,
+  type NodeData,
+  type Point,
+  type PositionedNode,
+} from '@graph-render/types';
 
 import { DEFAULT_NODE_SIZE, DEFAULT_PADDING, getMaxNodeDimensions } from '../utils';
 import { gridLayout } from './grid';
@@ -77,7 +82,7 @@ export const centeredLayout = (
   const count = nodes.length;
 
   if (count === 0) {
-    return [] as PositionedNode[];
+    return [];
   }
 
   const { x: centerX, y: centerY } = getContainerCenter(width, height);
@@ -95,9 +100,7 @@ export const centeredLayout = (
   }
 
   return nodes.map((node, index) => {
-    if (node.position) {
-      return node as PositionedNode;
-    }
+    if (isPositionedNode(node)) return node;
 
     const nodeWidth = node.size?.width ?? DEFAULT_NODE_SIZE.width;
     const nodeHeight = node.size?.height ?? DEFAULT_NODE_SIZE.height;

--- a/src/core-graph-render/src/layouts/dag.ts
+++ b/src/core-graph-render/src/layouts/dag.ts
@@ -1,6 +1,7 @@
 import {
   type EdgeData,
   LayoutDirection,
+  makePositionedNode,
   type NodeData,
   type PositionedNode,
 } from '@graph-render/types';
@@ -66,13 +67,10 @@ export const dagLayout = (
         baseX +
         layerIndex * stepX +
         (direction === LayoutDirection.RTL ? maxNodeWidth - nodeWidth : 0);
-      const positioned = {
-        ...node,
-        position: {
-          x: layers.length > 1 ? x : pad + Math.max(0, (contentWidth - nodeWidth) / 2),
-          y,
-        },
-      } as PositionedNode;
+      const positioned = makePositionedNode(node, {
+        x: layers.length > 1 ? x : pad + Math.max(0, (contentWidth - nodeWidth) / 2),
+        y,
+      });
 
       y +=
         (node.size?.height ?? DEFAULT_NODE_SIZE.height) +

--- a/src/core-graph-render/src/layouts/forceDirected.ts
+++ b/src/core-graph-render/src/layouts/forceDirected.ts
@@ -8,31 +8,43 @@ interface MutablePoint {
   x: number;
   y: number;
 }
-// NOTE: this cache is intentionally module-level so warm hits persist across
-// sequential renders of the same graph (common during viewport-only updates).
-// Trade-off: all <Graph> instances in the same JS bundle share the same 24-slot
-// LRU.  Keys include the full node/edge topology, so stale hits are extremely
-// unlikely.  If you mount many independent graphs with similar-but-distinct
-// topologies and see layout lag, increase FORCE_LAYOUT_CACHE_LIMIT.
-const forceLayoutCache = new Map<string, readonly PositionedNode[]>();
+
+export type ForceLayoutCache = Map<string, readonly PositionedNode[]>;
+
+/**
+ * Creates an isolated force-layout LRU cache.
+ *
+ * In browser environments the module-level default cache is shared across all
+ * `<Graph>` instances, which is usually acceptable. In SSR environments (Next.js,
+ * Remix, etc.) you MUST create a per-request cache to prevent cross-request data
+ * leaks:
+ *
+ * ```ts
+ * // In your request handler / RSC:
+ * const layoutCache = createForceLayoutCache();
+ * // Pass it via GraphProps.forceLayoutCache (future) or use forceDirectedLayout directly.
+ * ```
+ */
+export const createForceLayoutCache = (): ForceLayoutCache =>
+  new Map<string, readonly PositionedNode[]>();
+
+// Module-level default cache for browser environments only.
+// All <Graph> instances sharing a JS bundle share this 24-slot LRU.
+// For SSR usage, create a per-request cache with createForceLayoutCache().
+const defaultForceLayoutCache: ForceLayoutCache = createForceLayoutCache();
 
 const finitePositive = (value: number, fallback: number): number => {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 };
 
-const serializeNodeLabel = (label: unknown): string | number | boolean | null => {
-  if (typeof label === 'string') {
-    return label.slice(0, 160);
-  }
-  if (typeof label === 'number' && Number.isFinite(label)) {
-    return label;
-  }
-  if (typeof label === 'boolean') {
-    return label;
-  }
-  return null;
-};
-
+/**
+ * Builds a cache key from topology-relevant data only.
+ *
+ * Layout positions depend on node identity, node sizes, edge topology, and layout
+ * parameters — NOT on label text. Using only IDs and sizes eliminates the previous
+ * label-truncation collision (two nodes differing only after character 160 would
+ * produce the same key) and avoids serialising potentially large label strings.
+ */
 const buildForceLayoutCacheKey = (
   nodes: readonly NodeData[],
   edges: readonly EdgeData[],
@@ -50,7 +62,6 @@ const buildForceLayoutCacheKey = (
       nodes: nodes.map((node) => ({
         id: node.id,
         size: node.size,
-        label: serializeNodeLabel(node.label),
       })),
       edges: edges.map((edge) => ({
         id: edge.id,
@@ -64,18 +75,21 @@ const buildForceLayoutCacheKey = (
   }
 };
 
-const getCachedForceLayout = (cacheKey: string | null): readonly PositionedNode[] | undefined => {
+const getCachedForceLayout = (
+  cacheKey: string | null,
+  cache: ForceLayoutCache
+): readonly PositionedNode[] | undefined => {
   if (!cacheKey) {
     return undefined;
   }
 
-  const cached = forceLayoutCache.get(cacheKey);
+  const cached = cache.get(cacheKey);
   if (!cached) {
     return undefined;
   }
 
-  forceLayoutCache.delete(cacheKey);
-  forceLayoutCache.set(cacheKey, cached);
+  cache.delete(cacheKey);
+  cache.set(cacheKey, cached);
   return cached.map((node) => {
     const size = node.size ? { ...node.size } : undefined;
     return {
@@ -86,19 +100,23 @@ const getCachedForceLayout = (cacheKey: string | null): readonly PositionedNode[
   });
 };
 
-const setCachedForceLayout = (cacheKey: string | null, nodes: readonly PositionedNode[]): void => {
+const setCachedForceLayout = (
+  cacheKey: string | null,
+  nodes: readonly PositionedNode[],
+  cache: ForceLayoutCache
+): void => {
   if (!cacheKey) {
     return;
   }
 
-  if (forceLayoutCache.size >= FORCE_LAYOUT_CACHE_LIMIT) {
-    const oldestKey = forceLayoutCache.keys().next().value;
+  if (cache.size >= FORCE_LAYOUT_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
     if (oldestKey) {
-      forceLayoutCache.delete(oldestKey);
+      cache.delete(oldestKey);
     }
   }
 
-  forceLayoutCache.set(
+  cache.set(
     cacheKey,
     nodes.map((node) => {
       const size = node.size ? { ...node.size } : undefined;
@@ -150,7 +168,8 @@ export const forceDirectedLayout = (
   pad: number = DEFAULT_PADDING,
   width = 960,
   height = 720,
-  gap: number = DEFAULT_NODE_GAP
+  gap: number = DEFAULT_NODE_GAP,
+  cache: ForceLayoutCache = defaultForceLayoutCache
 ): readonly PositionedNode[] => {
   const resolvedPad = finitePositive(pad, DEFAULT_PADDING);
   const resolvedWidth = finitePositive(width, 960);
@@ -173,7 +192,7 @@ export const forceDirectedLayout = (
     resolvedHeight,
     resolvedGap
   );
-  const cached = getCachedForceLayout(cacheKey);
+  const cached = getCachedForceLayout(cacheKey, cache);
   if (cached) {
     return cached;
   }
@@ -265,7 +284,7 @@ export const forceDirectedLayout = (
     };
   });
 
-  setCachedForceLayout(cacheKey, positionedNodes);
+  setCachedForceLayout(cacheKey, positionedNodes, cache);
 
   return positionedNodes;
 };

--- a/src/core-graph-render/src/layouts/grid.ts
+++ b/src/core-graph-render/src/layouts/grid.ts
@@ -1,4 +1,9 @@
-import type { NodeData, Point, PositionedNode } from '@graph-render/types';
+import {
+  isPositionedNode,
+  type NodeData,
+  type Point,
+  type PositionedNode,
+} from '@graph-render/types';
 
 import { DEFAULT_NODE_GAP, DEFAULT_NODE_SIZE, DEFAULT_PADDING } from '../utils';
 
@@ -40,7 +45,7 @@ export const gridLayout = (
   const cols = calculateGridColumns(count);
 
   return nodes.map((node, idx) => {
-    if (node.position) return node as PositionedNode;
+    if (isPositionedNode(node)) return node;
 
     const nodeWidth = node.size?.width ?? DEFAULT_NODE_SIZE.width;
     const nodeHeight = node.size?.height ?? DEFAULT_NODE_SIZE.height;

--- a/src/core-graph-render/src/layouts/index.ts
+++ b/src/core-graph-render/src/layouts/index.ts
@@ -1,4 +1,5 @@
 import {
+  isPositionedNode,
   LayoutDirection,
   type LayoutOptions,
   LayoutType,
@@ -131,7 +132,7 @@ export const layoutNodes = (options: LayoutOptions): readonly PositionedNode[] =
   const missingPositions = sizedNodes.some((node) => !node.position);
 
   if (!missingPositions) {
-    return sizedNodes as PositionedNode[];
+    return sizedNodes.filter((n): n is PositionedNode => isPositionedNode(n));
   }
 
   const fixedNodes = sizedNodes.filter((node): node is PositionedNode => Boolean(node.position));
@@ -159,7 +160,11 @@ export const layoutNodes = (options: LayoutOptions): readonly PositionedNode[] =
 export { centeredLayout } from './centered';
 export { compactBracketLayout } from './compactBracket';
 export { dagLayout } from './dag';
-export { forceDirectedLayout } from './forceDirected';
+export {
+  createForceLayoutCache,
+  forceDirectedLayout,
+  type ForceLayoutCache,
+} from './forceDirected';
 export { gridLayout } from './grid';
 export { orthogonalFlowLayout } from './orthogonalFlow';
 export { radialTreeLayout } from './radialTree';

--- a/src/core-graph-render/src/layouts/treeAlignment.ts
+++ b/src/core-graph-render/src/layouts/treeAlignment.ts
@@ -1,9 +1,11 @@
-import type {
-  EdgeData,
-  LayoutDirection,
-  NodeData,
-  PositionedNode,
-  TreeMetrics,
+import {
+  type EdgeData,
+  isPositionedNode,
+  type LayoutDirection,
+  makePositionedNode,
+  type NodeData,
+  type PositionedNode,
+  type TreeMetrics,
 } from '@graph-render/types';
 
 import { DEFAULT_NODE_SIZE } from '../utils';
@@ -22,7 +24,7 @@ export const positionNodesInLevels = (
   direction: LayoutDirection
 ): readonly PositionedNode[] => {
   return nodes.map((node) => {
-    if (node.position) return node as PositionedNode;
+    if (isPositionedNode(node)) return node;
 
     const level = levelMap.get(node.id) ?? 0;
     const levelNodes = levels[level] ?? [];
@@ -91,10 +93,7 @@ export const alignNodesToParents = (
 
       const h = node.size?.height ?? DEFAULT_NODE_SIZE.height;
       const newY = avgCenterY - h / 2;
-      const updated = {
-        ...node,
-        position: { ...node.position, y: newY },
-      } as PositionedNode;
+      const updated = makePositionedNode(node, { ...node.position, y: newY });
       posMap.set(id, updated);
     }
   }

--- a/src/react-graph-render/package.json
+++ b/src/react-graph-render/package.json
@@ -60,7 +60,7 @@
     "node": ">=20.19.0"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
+    "react": ">=18.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
@@ -70,7 +70,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.4",
     "jsdom": "^29.1.1",
-    "react": "^19.0.0",
+    "react": ">=18.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.10",

--- a/src/react-graph-render/src/components/EdgePath.tsx
+++ b/src/react-graph-render/src/components/EdgePath.tsx
@@ -1,7 +1,7 @@
 import { buildEdgePath } from '@graph-render/core';
 import { EdgeType } from '@graph-render/types';
 import type { EdgePathProps } from '@graph-render/types/react';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 // Memoised so that unchanged edges are skipped during re-renders of the parent
 // Graph component (e.g. when hover/selection state changes for a different edge).
@@ -30,6 +30,12 @@ export const EdgePath = React.memo(function EdgePath({
   onClick,
 }: EdgePathProps) {
   const [isFocused, setIsFocused] = useState(false);
+  const handleMouseEnter = useCallback(() => {
+    if (hoverEnabled) onHoverChange?.(true);
+  }, [hoverEnabled, onHoverChange]);
+  const handleMouseLeave = useCallback(() => {
+    if (hoverEnabled) onHoverChange?.(false);
+  }, [hoverEnabled, onHoverChange]);
   const d = buildEdgePath(edge, curveEdges, curveStrength);
   if (!d) return null;
 
@@ -61,8 +67,8 @@ export const EdgePath = React.memo(function EdgePath({
           onClick ? (edge.label != null ? `Edge: ${String(edge.label)}` : 'Graph edge') : undefined
         }
         aria-pressed={onClick && selectionEnabled ? isSelected : undefined}
-        onMouseEnter={() => hoverEnabled && onHoverChange?.(true)}
-        onMouseLeave={() => hoverEnabled && onHoverChange?.(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         onClick={onClick}

--- a/src/react-graph-render/src/components/GraphCanvas.tsx
+++ b/src/react-graph-render/src/components/GraphCanvas.tsx
@@ -8,12 +8,16 @@ import { RoutingStyle } from '@graph-render/types';
 import type {
   EdgeComponent,
   GraphControlsPosition,
+  GraphErrorContext,
   GraphRenderContext,
   GraphViewport,
   VertexComponent,
 } from '@graph-render/types/react';
-import React from 'react';
+import { GraphErrorPhase } from '@graph-render/types/react';
+import React, { useMemo } from 'react';
 
+import type { GraphNodeTheme } from '../contexts/GraphThemeContext';
+import { GraphThemeProvider } from '../contexts/GraphThemeContext';
 import type { Rect } from '../models/domain';
 import type { NodeMeasurementScheduler } from '../utils/nodeMeasurementScheduler';
 import { GraphEdgesLayer } from './GraphEdgesLayer';
@@ -36,6 +40,7 @@ export interface GraphCanvasProps {
   readonly renderBackground?: ((context: GraphRenderContext) => React.ReactNode) | undefined;
   readonly renderOverlay?: ((context: GraphRenderContext) => React.ReactNode) | undefined;
   readonly renderContext: GraphRenderContext;
+  readonly onRenderPropError?: ((error: Error, context: GraphErrorContext) => void) | undefined;
   readonly showArrows: boolean;
   readonly arrowMarkerId: string;
   readonly hoverArrowMarkerId: string;
@@ -108,7 +113,23 @@ export interface GraphCanvasProps {
   readonly handlePointerUp: (event: React.PointerEvent<SVGSVGElement>) => void;
   readonly handlePointerCancel: (event: React.PointerEvent<SVGSVGElement>) => void;
   readonly handleKeyDown: (event: React.KeyboardEvent<SVGSVGElement>) => void;
+  readonly ariaLabel?: string | undefined;
 }
+
+const safeCallRenderProp = (
+  fn: ((context: GraphRenderContext) => React.ReactNode) | undefined,
+  context: GraphRenderContext,
+  onError: ((error: Error, ctx: GraphErrorContext) => void) | undefined
+): React.ReactNode => {
+  if (!fn) return null;
+  try {
+    return fn(context);
+  } catch (error_) {
+    const error = error_ instanceof Error ? error_ : new Error(String(error_));
+    onError?.(error, { graph: context.graph, phase: GraphErrorPhase.Render });
+    return null;
+  }
+};
 
 export const GraphCanvas = React.memo(function GraphCanvas({
   svgRef,
@@ -123,6 +144,7 @@ export const GraphCanvas = React.memo(function GraphCanvas({
   renderBackground,
   renderOverlay,
   renderContext,
+  onRenderPropError,
   showArrows,
   arrowMarkerId,
   hoverArrowMarkerId,
@@ -193,14 +215,19 @@ export const GraphCanvas = React.memo(function GraphCanvas({
   handlePointerUp,
   handlePointerCancel,
   handleKeyDown,
+  ariaLabel = 'Graph',
 }: GraphCanvasProps) {
+  const nodeTheme = useMemo<GraphNodeTheme>(
+    () => ({ nodeFill, nodeStroke, nodeTextColor, nodeTextSize, nodeRadius, fontFamily }),
+    [nodeFill, nodeStroke, nodeTextColor, nodeTextSize, nodeRadius, fontFamily]
+  );
   return (
     <svg
       ref={svgRef}
       width={cfg.width}
       height={cfg.height}
       role={svgRole}
-      aria-label="Graph"
+      aria-label={ariaLabel}
       aria-describedby={svgDescId}
       tabIndex={0}
       style={svgStyle}
@@ -231,7 +258,7 @@ export const GraphCanvas = React.memo(function GraphCanvas({
 
       <g transform={`translate(${viewport.x}, ${viewport.y}) scale(${viewport.zoom})`}>
         <g ref={contentRef}>
-          {renderBackground?.(renderContext)}
+          {safeCallRenderProp(renderBackground, renderContext, onRenderPropError)}
 
           <GraphLabels
             positionedNodes={positionedNodes}
@@ -274,43 +301,39 @@ export const GraphCanvas = React.memo(function GraphCanvas({
             onEdgeSelection={handleEdgeSelection}
           />
 
-          <GraphNodesLayer
-            nodes={culledNodes}
-            Vertex={Vertex}
-            selectedNodeSet={selectedNodeSet}
-            nodeSelectionEnabled={nodeSelectionEnabled}
-            focusedNodeId={effectiveFocusedNodeId}
-            highlightedNodeSet={effectiveHighlightedNodeSet}
-            activePathKey={focusedPathKey}
-            activePathNodeIds={activePathNodeIds}
-            highlightColor={highlightColor}
-            selectionColor={selectionColor}
-            nodeBorderColor={nodeBorderColor}
-            nodeBorderWidth={nodeBorderWidth}
-            hoverNodeBorderColor={hoverNodeBorderColor}
-            hoverNodeBothColor={hoverNodeBothColor}
-            hoverNodeInColor={hoverNodeInColor}
-            hoverNodeOutColor={hoverNodeOutColor}
-            hoverNodeHighlight={hoverNodeHighlight}
-            hoveredNodeStates={hoveredNodeStates ?? undefined}
-            measurementScheduler={measurementScheduler}
-            onNodeMeasure={handleNodeMeasure}
-            onNodeFocus={updateFocusedNode}
-            onNodeClick={handleNodeSelection}
-            onNodeDoubleClick={handleNodeDoubleClick}
-            onNodeMouseEnter={handleNodeMouseEnter}
-            onNodeMouseLeave={handleNodeMouseLeave}
-            onPathHover={handlePathHover}
-            onPathLeave={handlePathLeave}
-            nodeFill={nodeFill}
-            nodeStroke={nodeStroke}
-            nodeTextColor={nodeTextColor}
-            nodeTextSize={nodeTextSize}
-            nodeRadius={nodeRadius}
-            fontFamily={fontFamily}
-          />
+          <GraphThemeProvider theme={nodeTheme}>
+            <GraphNodesLayer
+              nodes={culledNodes}
+              Vertex={Vertex}
+              selectedNodeSet={selectedNodeSet}
+              nodeSelectionEnabled={nodeSelectionEnabled}
+              focusedNodeId={effectiveFocusedNodeId}
+              highlightedNodeSet={effectiveHighlightedNodeSet}
+              activePathKey={focusedPathKey}
+              activePathNodeIds={activePathNodeIds}
+              highlightColor={highlightColor}
+              selectionColor={selectionColor}
+              nodeBorderColor={nodeBorderColor}
+              nodeBorderWidth={nodeBorderWidth}
+              hoverNodeBorderColor={hoverNodeBorderColor}
+              hoverNodeBothColor={hoverNodeBothColor}
+              hoverNodeInColor={hoverNodeInColor}
+              hoverNodeOutColor={hoverNodeOutColor}
+              hoverNodeHighlight={hoverNodeHighlight}
+              hoveredNodeStates={hoveredNodeStates ?? undefined}
+              measurementScheduler={measurementScheduler}
+              onNodeMeasure={handleNodeMeasure}
+              onNodeFocus={updateFocusedNode}
+              onNodeClick={handleNodeSelection}
+              onNodeDoubleClick={handleNodeDoubleClick}
+              onNodeMouseEnter={handleNodeMouseEnter}
+              onNodeMouseLeave={handleNodeMouseLeave}
+              onPathHover={handlePathHover}
+              onPathLeave={handlePathLeave}
+            />
+          </GraphThemeProvider>
 
-          {renderOverlay?.(renderContext)}
+          {safeCallRenderProp(renderOverlay, renderContext, onRenderPropError)}
         </g>
       </g>
 

--- a/src/react-graph-render/src/components/GraphCanvas.tsx
+++ b/src/react-graph-render/src/components/GraphCanvas.tsx
@@ -19,6 +19,7 @@ import React, { useMemo } from 'react';
 import type { GraphNodeTheme } from '../contexts/GraphThemeContext';
 import { GraphThemeProvider } from '../contexts/GraphThemeContext';
 import type { Rect } from '../models/domain';
+import type { EdgeRenderState } from '../utils/edgeRenderState';
 import type { NodeMeasurementScheduler } from '../utils/nodeMeasurementScheduler';
 import { GraphEdgesLayer } from './GraphEdgesLayer';
 import { GraphLabels } from './GraphLabels';
@@ -52,9 +53,8 @@ export interface GraphCanvasProps {
   readonly culledEdgesForRender: readonly PositionedEdge[];
   readonly culledNodes: readonly PositionedNode[];
   readonly positionedNodes: readonly PositionedNode[];
-  readonly hoveredEdgeId: string | null;
-  readonly hoveredNodeId: string | null;
-  readonly pathHighlightEdges: ReadonlySet<string> | undefined;
+  /** Pre-computed per-edge hover/path state produced by useGraphHoverEngine. */
+  readonly edgeRenderStates: ReadonlyMap<string, EdgeRenderState>;
   readonly selectedEdgeSet: ReadonlySet<string>;
   readonly edgeSelectionEnabled: boolean;
   readonly edgeInteractive: boolean;
@@ -156,9 +156,7 @@ export const GraphCanvas = React.memo(function GraphCanvas({
   culledEdgesForRender,
   culledNodes,
   positionedNodes,
-  hoveredEdgeId,
-  hoveredNodeId,
-  pathHighlightEdges,
+  edgeRenderStates,
   selectedEdgeSet,
   edgeSelectionEnabled,
   edgeInteractive,
@@ -286,9 +284,7 @@ export const GraphCanvas = React.memo(function GraphCanvas({
             hoverIncomingArrowMarkerId={hoverIncomingArrowMarkerId}
             selectionArrowMarkerId={selectionArrowMarkerId}
             hoverHighlight={cfg.hoverHighlight}
-            hoveredEdgeId={hoveredEdgeId}
-            hoveredNodeId={hoveredNodeId}
-            pathHighlightEdges={pathHighlightEdges}
+            edgeRenderStates={edgeRenderStates}
             selectedEdgeSet={selectedEdgeSet}
             edgeSelectionEnabled={edgeSelectionEnabled}
             edgeInteractive={edgeInteractive}

--- a/src/react-graph-render/src/components/GraphEdgesLayer.tsx
+++ b/src/react-graph-render/src/components/GraphEdgesLayer.tsx
@@ -2,7 +2,9 @@ import type { PositionedEdge } from '@graph-render/types';
 import type { EdgeComponent } from '@graph-render/types/react';
 import React, { useCallback } from 'react';
 
-import { getEdgeRenderState } from '../utils/edgeRenderState';
+import type { EdgeRenderState } from '../utils/edgeRenderState';
+
+const FALLBACK_RENDER_STATE: EdgeRenderState = { edgeHovered: false, isIncomingToHovered: false };
 
 interface GraphEdgesLayerProps {
   readonly edges: readonly PositionedEdge[];
@@ -17,10 +19,10 @@ interface GraphEdgesLayerProps {
   readonly hoverArrowMarkerId: string;
   readonly hoverIncomingArrowMarkerId: string;
   readonly selectionArrowMarkerId: string;
+  /** Pre-computed per-edge hover/path state. Produced by useGraphHoverEngine. */
+  readonly edgeRenderStates: ReadonlyMap<string, EdgeRenderState>;
+  /** Whether hover highlighting is enabled (from config). Controls EdgeComponent event handlers. */
   readonly hoverHighlight: boolean;
-  readonly hoveredEdgeId: string | null;
-  readonly hoveredNodeId: string | null;
-  readonly pathHighlightEdges?: ReadonlySet<string> | undefined;
   readonly selectedEdgeSet: ReadonlySet<string>;
   readonly edgeSelectionEnabled: boolean;
   readonly edgeInteractive: boolean;
@@ -123,10 +125,8 @@ export const GraphEdgesLayer = React.memo(function GraphEdgesLayer({
   hoverArrowMarkerId,
   hoverIncomingArrowMarkerId,
   selectionArrowMarkerId,
+  edgeRenderStates,
   hoverHighlight,
-  hoveredEdgeId,
-  hoveredNodeId,
-  pathHighlightEdges,
   selectedEdgeSet,
   edgeSelectionEnabled,
   edgeInteractive,
@@ -141,12 +141,8 @@ export const GraphEdgesLayer = React.memo(function GraphEdgesLayer({
   return (
     <g aria-label="edges">
       {edges.map((edge) => {
-        const { edgeHovered, isIncomingToHovered } = getEdgeRenderState(edge, {
-          hoverHighlight,
-          hoveredEdgeId,
-          hoveredNodeId,
-          pathHighlightEdges,
-        });
+        const { edgeHovered, isIncomingToHovered } =
+          edgeRenderStates.get(edge.id) ?? FALLBACK_RENDER_STATE;
 
         return (
           <GraphEdgeItem

--- a/src/react-graph-render/src/components/GraphErrorBoundary.tsx
+++ b/src/react-graph-render/src/components/GraphErrorBoundary.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 export interface GraphErrorBoundaryProps {
   readonly children: React.ReactNode;
   readonly fallback?: React.ReactNode;
+  readonly fallbackClassName?: string | undefined;
+  readonly fallbackStyle?: React.CSSProperties | undefined;
   readonly onError?: ((error: Error, errorInfo: React.ErrorInfo) => void) | undefined;
   readonly resetKeys?: readonly unknown[] | undefined;
 }
@@ -42,6 +44,7 @@ export class GraphErrorBoundary extends React.Component<
       return (
         <div
           role="alert"
+          className={this.props.fallbackClassName}
           style={{
             padding: 16,
             borderRadius: 8,
@@ -50,6 +53,7 @@ export class GraphErrorBoundary extends React.Component<
             color: '#991b1b',
             fontFamily: 'system-ui, sans-serif',
             fontSize: 14,
+            ...this.props.fallbackStyle,
           }}
         >
           Graph failed to render: {this.state.error.message}

--- a/src/react-graph-render/src/components/GraphNode.tsx
+++ b/src/react-graph-render/src/components/GraphNode.tsx
@@ -3,6 +3,7 @@ import type { VertexComponent } from '@graph-render/types/react';
 import React, { useCallback } from 'react';
 
 import { DEFAULT_NODE_HEIGHT, DEFAULT_NODE_WIDTH } from '../constants/graph';
+import { useGraphTheme } from '../contexts/GraphThemeContext';
 import { useGraphNodeMeasurement } from '../hooks/useGraphNodeMeasurement';
 import { getGraphNodeFrameState } from '../utils/graphNodeFrame';
 import type { NodeMeasurementScheduler } from '../utils/nodeMeasurementScheduler';
@@ -38,12 +39,6 @@ interface GraphNodeProps {
   readonly onNodeMouseLeave: () => void;
   readonly onPathHover: (nodeId: string, sourceIndex: number, playerKey?: string) => void;
   readonly onPathLeave: () => void;
-  readonly nodeFill: string;
-  readonly nodeStroke: string;
-  readonly nodeTextColor: string;
-  readonly nodeTextSize: number;
-  readonly nodeRadius: number;
-  readonly fontFamily: string;
 }
 
 export const GraphNode = React.memo<GraphNodeProps>(
@@ -77,13 +72,9 @@ export const GraphNode = React.memo<GraphNodeProps>(
     onNodeMouseLeave,
     onPathHover,
     onPathLeave,
-    nodeFill,
-    nodeStroke,
-    nodeTextColor,
-    nodeTextSize,
-    nodeRadius,
-    fontFamily,
   }) => {
+    const { nodeFill, nodeStroke, nodeTextColor, nodeTextSize, nodeRadius, fontFamily } =
+      useGraphTheme();
     const width = node.size?.width ?? DEFAULT_NODE_WIDTH;
     const height = node.size?.height ?? DEFAULT_NODE_HEIGHT;
     const radius = nodeRadius;

--- a/src/react-graph-render/src/components/GraphNodesLayer.tsx
+++ b/src/react-graph-render/src/components/GraphNodesLayer.tsx
@@ -35,12 +35,6 @@ interface GraphNodesLayerProps {
   readonly onNodeMouseLeave: () => void;
   readonly onPathHover: (nodeId: string, sourceIndex: number, pathKey?: string) => void;
   readonly onPathLeave: () => void;
-  readonly nodeFill: string;
-  readonly nodeStroke: string;
-  readonly nodeTextColor: string;
-  readonly nodeTextSize: number;
-  readonly nodeRadius: number;
-  readonly fontFamily: string;
 }
 
 export const GraphNodesLayer = React.memo(function GraphNodesLayer({
@@ -71,12 +65,6 @@ export const GraphNodesLayer = React.memo(function GraphNodesLayer({
   onNodeMouseLeave,
   onPathHover,
   onPathLeave,
-  nodeFill,
-  nodeStroke,
-  nodeTextColor,
-  nodeTextSize,
-  nodeRadius,
-  fontFamily,
 }: GraphNodesLayerProps) {
   return (
     <g aria-label="nodes">
@@ -115,12 +103,6 @@ export const GraphNodesLayer = React.memo(function GraphNodesLayer({
             onNodeMouseLeave={onNodeMouseLeave}
             onPathHover={onPathHover}
             onPathLeave={onPathLeave}
-            nodeFill={nodeFill}
-            nodeStroke={nodeStroke}
-            nodeTextColor={nodeTextColor}
-            nodeTextSize={nodeTextSize}
-            nodeRadius={nodeRadius}
-            fontFamily={fontFamily}
           />
         );
       })}

--- a/src/react-graph-render/src/components/__tests__/Graph.integration.test.tsx
+++ b/src/react-graph-render/src/components/__tests__/Graph.integration.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Integration test for <Graph />.
+ *
+ * Uses real @graph-render/core (no mock). Only browser APIs that do not exist
+ * in jsdom are mocked: SVGElement.prototype.getBBox and ResizeObserver.
+ */
+import type { NxGraphInput } from '@graph-render/types';
+import type { VertexComponent } from '@graph-render/types/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { Graph } from '../Graph';
+
+// ── jsdom shims ──────────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  // jsdom does not implement SVGElement.getBBox
+  (SVGElement.prototype as unknown as { getBBox: () => SVGRect }).getBBox = () =>
+    ({ x: 0, y: 0, width: 0, height: 0 }) as SVGRect;
+
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class MockResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ThreeNodeVertex: VertexComponent = ({ node }) => (
+  <text data-testid={`node-${node.id}`}>{String(node.label ?? node.id)}</text>
+);
+
+const threeNodeGraph: NxGraphInput = {
+  nodes: { n1: { label: 'Node 1' }, n2: { label: 'Node 2' }, n3: { label: 'Node 3' } },
+  adj: {
+    n1: { n2: { id: 'e1' } },
+    n2: { n3: { id: 'e2' } },
+    n3: {},
+  },
+};
+
+const emptyGraph: NxGraphInput = { nodes: {}, adj: {} };
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Graph (integration)', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(
+      <Graph graph={threeNodeGraph} vertexComponent={ThreeNodeVertex} />
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders all three node vertices', async () => {
+    render(<Graph graph={threeNodeGraph} vertexComponent={ThreeNodeVertex} />);
+    await screen.findByTestId('node-n1');
+    await screen.findByTestId('node-n2');
+    await screen.findByTestId('node-n3');
+  });
+
+  it('does not crash when graph is empty', () => {
+    const EmptyVertex: VertexComponent = () => <text />;
+    expect(() => render(<Graph graph={emptyGraph} vertexComponent={EmptyVertex} />)).not.toThrow();
+  });
+
+  it('calls onLayoutChange after initial layout', async () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <Graph
+        graph={threeNodeGraph}
+        vertexComponent={ThreeNodeVertex}
+        onLayoutChange={onLayoutChange}
+      />
+    );
+    await waitFor(() => {
+      expect(onLayoutChange).toHaveBeenCalled();
+    });
+    const firstCall = onLayoutChange.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const { nodes, edges } = firstCall![0] as { nodes: unknown[]; edges: unknown[] };
+    expect(nodes.length).toBe(3);
+    expect(edges.length).toBe(2);
+  });
+
+  it('renders with fitViewOnMount without crashing', () => {
+    expect(() =>
+      render(
+        <Graph
+          graph={threeNodeGraph}
+          vertexComponent={ThreeNodeVertex}
+          fitViewOnMount
+          fitViewPadding={16}
+        />
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/react-graph-render/src/components/__tests__/Graph.test.tsx
+++ b/src/react-graph-render/src/components/__tests__/Graph.test.tsx
@@ -1,5 +1,6 @@
 import { fromTypedNxGraph } from '@graph-render/core';
 import { LayoutDirection, LayoutType, RoutingStyle } from '@graph-render/types';
+import type { VertexComponent } from '@graph-render/types/react';
 import { SelectionMode } from '@graph-render/types/react';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
@@ -67,8 +68,8 @@ vi.mock('@graph-render/core', () => ({
   normalizeEdges: vi.fn((edges: unknown[]) => edges),
 }));
 
-const StubVertex = ({ node }: any) => (
-  <text data-testid={`vertex-${node.id}`}>{node.label ?? node.id}</text>
+const StubVertex: VertexComponent = ({ node }) => (
+  <text data-testid={`vertex-${node.id}`}>{node.label != null ? String(node.label) : node.id}</text>
 );
 
 const emptyGraph = makeEmptyNxGraph();
@@ -86,7 +87,11 @@ describe('Graph', () => {
 
   it('uses role="figure" when keyboard navigation is disabled', () => {
     const { container } = render(
-      <Graph graph={emptyGraph} vertexComponent={StubVertex} keyboardNavigation={false} />
+      <Graph
+        graph={emptyGraph}
+        vertexComponent={StubVertex}
+        interaction={{ keyboardNavigation: false }}
+      />
     );
     expect(container.querySelector('svg[role="figure"]')).not.toBeNull();
   });
@@ -118,7 +123,11 @@ describe('Graph', () => {
 
   it('renders viewport controls when showControls is true', () => {
     const { container } = render(
-      <Graph graph={emptyGraph} vertexComponent={StubVertex} showControls />
+      <Graph
+        graph={emptyGraph}
+        vertexComponent={StubVertex}
+        viewportOptions={{ showControls: true }}
+      />
     );
     expect(container.querySelector('g[aria-label="viewport-controls"]')).not.toBeNull();
   });

--- a/src/react-graph-render/src/components/__tests__/GraphEdgesLayer.test.tsx
+++ b/src/react-graph-render/src/components/__tests__/GraphEdgesLayer.test.tsx
@@ -2,6 +2,7 @@ import { EdgeType } from '@graph-render/types';
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { EdgeRenderState } from '../../utils/edgeRenderState';
 import { GraphEdgesLayer } from '../GraphEdgesLayer';
 
 const makeEdge = (id: string) =>
@@ -42,8 +43,7 @@ const baseProps = {
   hoverIncomingArrowMarkerId: 'hover-in',
   selectionArrowMarkerId: 'sel-arrow',
   hoverHighlight: true,
-  hoveredEdgeId: null,
-  hoveredNodeId: null,
+  edgeRenderStates: new Map<string, EdgeRenderState>(),
   selectedEdgeSet: new Set<string>(),
   edgeSelectionEnabled: true,
   edgeInteractive: true,
@@ -153,10 +153,13 @@ describe('GraphEdgesLayer', () => {
     expect(onEdgeSelection).not.toHaveBeenCalled();
   });
 
-  it('passes isHovered=true when edge id matches hoveredEdgeId', () => {
+  it('passes isHovered=true when edge id is in edgeRenderStates with edgeHovered=true', () => {
+    const hoveredStates = new Map<string, EdgeRenderState>([
+      ['e1', { edgeHovered: true, isIncomingToHovered: false }],
+    ]);
     const { getByTestId } = render(
       <svg>
-        <GraphEdgesLayer {...baseProps} edges={[makeEdge('e1')]} hoveredEdgeId="e1" />
+        <GraphEdgesLayer {...baseProps} edges={[makeEdge('e1')]} edgeRenderStates={hoveredStates} />
       </svg>
     );
     expect(getByTestId('edge-e1').dataset['hovered']).toBe('true');

--- a/src/react-graph-render/src/components/__tests__/GraphNode.test.tsx
+++ b/src/react-graph-render/src/components/__tests__/GraphNode.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { GraphThemeProvider } from '../../contexts/GraphThemeContext';
 import { createNodeMeasurementScheduler } from '../../utils/nodeMeasurementScheduler';
 import { GraphNode } from '../GraphNode';
 
@@ -16,6 +17,15 @@ const makeNode = (id: string, overrides: Record<string, unknown> = {}) =>
     size: { width: 180, height: 72 },
     ...overrides,
   }) as any;
+
+const testTheme = {
+  nodeFill: 'white',
+  nodeStroke: '#d7dbe3',
+  nodeTextColor: '#111827',
+  nodeTextSize: 14,
+  nodeRadius: 8,
+  fontFamily: 'system-ui, sans-serif',
+};
 
 const baseProps = {
   Vertex: StubVertex,
@@ -39,73 +49,50 @@ const baseProps = {
   onNodeMouseLeave: vi.fn(),
   onPathHover: vi.fn(),
   onPathLeave: vi.fn(),
-  nodeFill: 'white',
-  nodeStroke: '#d7dbe3',
-  nodeTextColor: '#111827',
-  nodeTextSize: 14,
-  nodeRadius: 8,
-  fontFamily: 'system-ui, sans-serif',
 };
+
+const renderInTheme = (ui: React.ReactElement) =>
+  render(
+    <GraphThemeProvider theme={testTheme}>
+      <svg>{ui}</svg>
+    </GraphThemeProvider>
+  );
 
 describe('GraphNode', () => {
   it('renders a group element with role="button"', () => {
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={makeNode('n1')} />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNode {...baseProps} node={makeNode('n1')} />);
     expect(container.querySelector('g[role="button"]')).not.toBeNull();
   });
 
   it('renders a Vertex inside the node group', () => {
-    const { getByTestId } = render(
-      <svg>
-        <GraphNode {...baseProps} node={makeNode('n1')} />
-      </svg>
-    );
+    const { getByTestId } = renderInTheme(<GraphNode {...baseProps} node={makeNode('n1')} />);
     expect(getByTestId('vertex-n1')).toBeInTheDocument();
   });
 
   it('applies translate transform from node position', () => {
     const node = makeNode('n1', { position: { x: 50, y: 120 } });
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNode {...baseProps} node={node} />);
     const group = container.querySelector('g[data-graph-node-interactive]');
     expect(group?.getAttribute('transform')).toBe('translate(50, 120)');
   });
 
   it('uses node label as aria-label', () => {
     const node = makeNode('n1', { label: 'My Node' });
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNode {...baseProps} node={node} />);
     const group = container.querySelector('g[data-graph-node-interactive]');
     expect(group?.getAttribute('aria-label')).toBe('My Node');
   });
 
   it('uses node id as aria-label when label is not a string', () => {
     const node = makeNode('n1', { label: undefined });
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNode {...baseProps} node={node} />);
     const group = container.querySelector('g[data-graph-node-interactive]');
     expect(group?.getAttribute('aria-label')).toBe('n1');
   });
 
   it('has aria-pressed reflecting selection state', () => {
     const node = makeNode('n1');
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} isSelected />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNode {...baseProps} node={node} isSelected />);
     const group = container.querySelector('g[data-graph-node-interactive]');
     expect(group?.getAttribute('aria-pressed')).toBe('true');
   });
@@ -113,10 +100,8 @@ describe('GraphNode', () => {
   it('calls onNodeClick when clicked', () => {
     const onNodeClick = vi.fn();
     const node = makeNode('n1');
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} onNodeClick={onNodeClick} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={node} onNodeClick={onNodeClick} />
     );
     const group = container.querySelector('g[data-graph-node-interactive]');
     fireEvent.click(group!);
@@ -126,10 +111,8 @@ describe('GraphNode', () => {
   it('calls onNodeMouseEnter when mouse enters', () => {
     const onNodeMouseEnter = vi.fn();
     const node = makeNode('n1');
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} onNodeMouseEnter={onNodeMouseEnter} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={node} onNodeMouseEnter={onNodeMouseEnter} />
     );
     const group = container.querySelector('g[data-graph-node-interactive]');
     fireEvent.mouseEnter(group!);
@@ -139,10 +122,8 @@ describe('GraphNode', () => {
   it('calls onNodeMouseLeave when mouse leaves', () => {
     const onNodeMouseLeave = vi.fn();
     const node = makeNode('n1');
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} onNodeMouseLeave={onNodeMouseLeave} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={node} onNodeMouseLeave={onNodeMouseLeave} />
     );
     const group = container.querySelector('g[data-graph-node-interactive]');
     fireEvent.mouseLeave(group!);
@@ -152,10 +133,8 @@ describe('GraphNode', () => {
   it('calls onNodeDoubleClick when double-clicked', () => {
     const onNodeDoubleClick = vi.fn();
     const node = makeNode('n1');
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} onNodeDoubleClick={onNodeDoubleClick} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={node} onNodeDoubleClick={onNodeDoubleClick} />
     );
     const group = container.querySelector('g[data-graph-node-interactive]');
     fireEvent.dblClick(group!);
@@ -165,10 +144,8 @@ describe('GraphNode', () => {
   it('calls onNodeClick when Enter key pressed', () => {
     const onNodeClick = vi.fn();
     const node = makeNode('n1');
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={node} onNodeClick={onNodeClick} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={node} onNodeClick={onNodeClick} />
     );
     const group = container.querySelector('g[data-graph-node-interactive]');
     fireEvent.keyDown(group!, { key: 'Enter' });
@@ -176,10 +153,8 @@ describe('GraphNode', () => {
   });
 
   it('renders a focus rect when isFocused is true', () => {
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={makeNode('n1')} isFocused />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={makeNode('n1')} isFocused />
     );
     // GraphNodeFrame renders 2 rects when focused
     const rects = container.querySelectorAll('rect');
@@ -187,10 +162,8 @@ describe('GraphNode', () => {
   });
 
   it('renders only 1 rect when isFocused is false', () => {
-    const { container } = render(
-      <svg>
-        <GraphNode {...baseProps} node={makeNode('n1')} isFocused={false} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNode {...baseProps} node={makeNode('n1')} isFocused={false} />
     );
     expect(container.querySelectorAll('rect')).toHaveLength(1);
   });

--- a/src/react-graph-render/src/components/__tests__/GraphNodesLayer.test.tsx
+++ b/src/react-graph-render/src/components/__tests__/GraphNodesLayer.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { GraphThemeProvider } from '../../contexts/GraphThemeContext';
 import { createNodeMeasurementScheduler } from '../../utils/nodeMeasurementScheduler';
 import { GraphNodesLayer } from '../GraphNodesLayer';
 
@@ -16,6 +17,15 @@ const makeNode = (id: string, overrides: Record<string, unknown> = {}) =>
     size: { width: 180, height: 72 },
     ...overrides,
   }) as any;
+
+const testTheme = {
+  nodeFill: 'white',
+  nodeStroke: '#d7dbe3',
+  nodeTextColor: '#111827',
+  nodeTextSize: 14,
+  nodeRadius: 8,
+  fontFamily: 'system-ui, sans-serif',
+};
 
 const baseProps = {
   Vertex: StubVertex,
@@ -40,56 +50,43 @@ const baseProps = {
   onNodeMouseLeave: vi.fn(),
   onPathHover: vi.fn(),
   onPathLeave: vi.fn(),
-  nodeFill: 'white',
-  nodeStroke: '#d7dbe3',
-  nodeTextColor: '#111827',
-  nodeTextSize: 14,
-  nodeRadius: 8,
-  fontFamily: 'system-ui, sans-serif',
 };
+
+const renderInTheme = (ui: React.ReactElement) =>
+  render(
+    <GraphThemeProvider theme={testTheme}>
+      <svg>{ui}</svg>
+    </GraphThemeProvider>
+  );
 
 describe('GraphNodesLayer', () => {
   it('renders a group with aria-label="nodes"', () => {
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer {...baseProps} nodes={[]} />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNodesLayer {...baseProps} nodes={[]} />);
     expect(container.querySelector('g[aria-label="nodes"]')).not.toBeNull();
   });
 
   it('renders nothing when nodes is empty', () => {
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer {...baseProps} nodes={[]} />
-      </svg>
-    );
+    const { container } = renderInTheme(<GraphNodesLayer {...baseProps} nodes={[]} />);
     expect(container.querySelectorAll('[data-graph-node-interactive]')).toHaveLength(0);
   });
 
   it('renders one node group per node', () => {
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer {...baseProps} nodes={[makeNode('n1'), makeNode('n2')]} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNodesLayer {...baseProps} nodes={[makeNode('n1'), makeNode('n2')]} />
     );
     expect(container.querySelectorAll('[data-graph-node-interactive]')).toHaveLength(2);
   });
 
   it('renders vertex for each node', () => {
-    const { getAllByTestId } = render(
-      <svg>
-        <GraphNodesLayer {...baseProps} nodes={[makeNode('n1'), makeNode('n2')]} />
-      </svg>
+    const { getAllByTestId } = renderInTheme(
+      <GraphNodesLayer {...baseProps} nodes={[makeNode('n1'), makeNode('n2')]} />
     );
     expect(getAllByTestId(/^vertex-/)).toHaveLength(2);
   });
 
   it('renders focused rect for focused node', () => {
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer {...baseProps} nodes={[makeNode('n1')]} focusedNodeId="n1" />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNodesLayer {...baseProps} nodes={[makeNode('n1')]} focusedNodeId="n1" />
     );
     // GraphNodeFrame renders 2 rects when focused
     expect(container.querySelectorAll('rect').length).toBeGreaterThanOrEqual(2);
@@ -97,10 +94,8 @@ describe('GraphNodesLayer', () => {
 
   it('calls onNodeClick when a node is clicked', () => {
     const onNodeClick = vi.fn();
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer {...baseProps} nodes={[makeNode('n1')]} onNodeClick={onNodeClick} />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNodesLayer {...baseProps} nodes={[makeNode('n1')]} onNodeClick={onNodeClick} />
     );
     const nodeGroup = container.querySelector('[data-graph-node-interactive]');
     fireEvent.click(nodeGroup!);
@@ -109,14 +104,12 @@ describe('GraphNodesLayer', () => {
 
   it('calls onNodeMouseEnter when a node is hovered', () => {
     const onNodeMouseEnter = vi.fn();
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer
-          {...baseProps}
-          nodes={[makeNode('n1')]}
-          onNodeMouseEnter={onNodeMouseEnter}
-        />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNodesLayer
+        {...baseProps}
+        nodes={[makeNode('n1')]}
+        onNodeMouseEnter={onNodeMouseEnter}
+      />
     );
     const nodeGroup = container.querySelector('[data-graph-node-interactive]');
     fireEvent.mouseEnter(nodeGroup!);
@@ -125,14 +118,12 @@ describe('GraphNodesLayer', () => {
 
   it('calls onNodeMouseLeave when a node is un-hovered', () => {
     const onNodeMouseLeave = vi.fn();
-    const { container } = render(
-      <svg>
-        <GraphNodesLayer
-          {...baseProps}
-          nodes={[makeNode('n1')]}
-          onNodeMouseLeave={onNodeMouseLeave}
-        />
-      </svg>
+    const { container } = renderInTheme(
+      <GraphNodesLayer
+        {...baseProps}
+        nodes={[makeNode('n1')]}
+        onNodeMouseLeave={onNodeMouseLeave}
+      />
     );
     const nodeGroup = container.querySelector('[data-graph-node-interactive]');
     fireEvent.mouseLeave(nodeGroup!);

--- a/src/react-graph-render/src/contexts/GraphThemeContext.tsx
+++ b/src/react-graph-render/src/contexts/GraphThemeContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, type ReactNode, useContext } from 'react';
+
+/** Static theme tokens derived from `config.theme` that are shared by every node. */
+export interface GraphNodeTheme {
+  readonly nodeFill: string;
+  readonly nodeStroke: string;
+  readonly nodeTextColor: string;
+  readonly nodeTextSize: number;
+  readonly nodeRadius: number;
+  readonly fontFamily: string;
+}
+
+const GraphThemeContext = createContext<GraphNodeTheme | null>(null);
+
+GraphThemeContext.displayName = 'GraphThemeContext';
+
+interface GraphThemeProviderProps {
+  readonly theme: GraphNodeTheme;
+  readonly children: ReactNode;
+}
+
+export const GraphThemeProvider = ({ theme, children }: GraphThemeProviderProps) => (
+  <GraphThemeContext.Provider value={theme}>{children}</GraphThemeContext.Provider>
+);
+
+/**
+ * Returns the nearest `GraphNodeTheme` from context.
+ * Must be called inside a `<GraphThemeProvider>`.
+ */
+export const useGraphTheme = (): GraphNodeTheme => {
+  const ctx = useContext(GraphThemeContext);
+  if (!ctx) {
+    throw new Error('useGraphTheme must be used inside <GraphThemeProvider>');
+  }
+  return ctx;
+};

--- a/src/react-graph-render/src/hooks/useGraphController.ts
+++ b/src/react-graph-render/src/hooks/useGraphController.ts
@@ -275,8 +275,7 @@ export const useGraphController = (
   });
 
   const {
-    hoveredEdgeId,
-    hoveredNodeId,
+    edgeRenderStates,
     focusedPath,
     setFocusedPath,
     pathHighlight,
@@ -446,9 +445,7 @@ export const useGraphController = (
     culledEdgesForRender,
     culledNodes,
     positionedNodes,
-    hoveredEdgeId,
-    hoveredNodeId,
-    pathHighlightEdges: pathHighlight?.edges,
+    edgeRenderStates,
     selectedEdgeSet,
     edgeSelectionEnabled,
     edgeInteractive: edgeSelectionEnabled || Boolean(onEdgeClick),

--- a/src/react-graph-render/src/hooks/useGraphController.ts
+++ b/src/react-graph-render/src/hooks/useGraphController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- useGraphController destructures deprecated flat props from GraphProps to bridge them to the new grouped-options API via resolveGraphProps. */
 import { normalizeGraphConfig } from '@graph-render/core';
 import { NodeSizingMode } from '@graph-render/types';
 import type { GraphHandle, GraphProps, GraphRenderContext } from '@graph-render/types/react';
@@ -22,16 +23,14 @@ import { normalizeZoomRange } from '../utils/viewport';
 import { useGraphCollapse } from './useGraphCollapse';
 import { useGraphCollapseHandlers } from './useGraphCollapseHandlers';
 import { useGraphCulling } from './useGraphCulling';
-import { useGraphHover } from './useGraphHover';
-import { useGraphHoverHandlers } from './useGraphHoverHandlers';
+import { useGraphHoverEngine } from './useGraphHoverEngine';
 import { useGraphKeyboardNavigation } from './useGraphKeyboardNavigation';
 import { useGraphModel } from './useGraphModel';
 import { useGraphPointerInteractions } from './useGraphPointerInteractions';
 import { useGraphRenderBindings } from './useGraphRenderBindings';
-import { useGraphSelectionHandlers } from './useGraphSelectionHandlers';
+import { useGraphSelectionEngine } from './useGraphSelectionEngine';
 import { useGraphViewportController } from './useGraphViewportController';
 import { useGraphViewState } from './useGraphViewState';
-import { useGraphVisibleSelection } from './useGraphVisibleSelection';
 import { useGraphWheelZoomListener } from './useGraphWheelZoomListener';
 import { useStableConfig } from './useStableConfig';
 
@@ -101,6 +100,7 @@ export const useGraphController = (
     onEdgeHoverChange,
     onNodeClick,
     onEdgeClick,
+    ariaLabel,
   } = props;
 
   const { panEnabled, zoomEnabled, pinchZoomEnabled, keyboardNavigation, marqueeSelectionEnabled } =
@@ -222,16 +222,27 @@ export const useGraphController = (
     updateCollapsedNodeIds,
   });
 
-  const { effectiveFocusedNodeId, effectiveSelection, selectedEdgeSet, selectedNodeSet } =
-    useGraphVisibleSelection({
-      focusedNodeId,
-      selection,
-      selectionRef,
-      updateFocusedNode,
-      updateSelection,
-      visibleEdges,
-      visibleNodes: visibleNodesWithMeasuredSize,
-    });
+  const {
+    effectiveFocusedNodeId,
+    effectiveSelection,
+    selectedEdgeSet,
+    selectedNodeSet,
+    handleEdgeSelection,
+    handleNodeSelection,
+  } = useGraphSelectionEngine({
+    focusedNodeId,
+    selection,
+    selectionRef,
+    updateFocusedNode,
+    updateSelection,
+    visibleEdges,
+    visibleNodes: visibleNodesWithMeasuredSize,
+    edgeSelectionEnabled,
+    nodeSelectionEnabled,
+    onEdgeClick,
+    onNodeClick,
+    selectionMode,
+  });
 
   const positionedNodeMap = useMemo(
     () => new Map(positionedNodes.map((n) => [n.id, n])),
@@ -244,15 +255,18 @@ export const useGraphController = (
 
   const { centerOnNode, fitView, getViewportDimensions } = useGraphViewportController({
     cfg,
+    collapsedIds,
     fitViewOnMount,
     fitViewPadding,
     graph,
+    pendingExpansionNodeSet,
     positionedEdges,
     positionedNodeMap,
     positionedNodes,
     ref,
     safeMaxZoom,
     safeMinZoom,
+    selectionRef,
     svgRef,
     updateSelection,
     updateViewport,
@@ -262,15 +276,28 @@ export const useGraphController = (
 
   const {
     hoveredEdgeId,
-    setHoveredEdgeId,
     hoveredNodeId,
-    setHoveredNodeId,
     focusedPath,
     setFocusedPath,
     pathHighlight,
     hoveredNodeStates,
     edgesForRender,
-  } = useGraphHover(positionedNodes, positionedEdges, cfg.hoverHighlight);
+    handleEdgeHoverChange,
+    handleNodeMouseEnter,
+    handleNodeMouseLeave,
+    handlePathHover,
+    handlePathLeave,
+  } = useGraphHoverEngine({
+    hoverHighlight: cfg.hoverHighlight,
+    positionedNodes,
+    positionedEdges,
+    positionedNodeMap,
+    positionedEdgeMap,
+    selection: effectiveSelection,
+    viewport,
+    onNodeHoverChange,
+    onEdgeHoverChange,
+  });
 
   const renderContext = useMemo<GraphRenderContext>(
     () => ({
@@ -297,16 +324,6 @@ export const useGraphController = (
       selection: selectionRef.current,
     });
   }, [cfg, graph, positionedEdges, positionedNodes, selectionRef, viewportRef]);
-
-  const { handleEdgeSelection, handleNodeSelection } = useGraphSelectionHandlers({
-    edgeSelectionEnabled,
-    nodeSelectionEnabled,
-    onEdgeClick,
-    onNodeClick,
-    selectionMode,
-    updateFocusedNode,
-    updateSelection,
-  });
 
   const {
     handlePointerCancel,
@@ -370,25 +387,6 @@ export const useGraphController = (
     zoomStep,
   });
 
-  const {
-    handleEdgeHoverChange,
-    handleNodeMouseEnter,
-    handleNodeMouseLeave,
-    handlePathHover,
-    handlePathLeave,
-  } = useGraphHoverHandlers({
-    hoverHighlight: cfg.hoverHighlight,
-    onEdgeHoverChange,
-    onNodeHoverChange,
-    positionedEdgeMap,
-    positionedNodeMap,
-    selection: effectiveSelection,
-    setFocusedPath,
-    setHoveredEdgeId,
-    setHoveredNodeId,
-    viewport,
-  });
-
   const renderBindings = useGraphRenderBindings({
     cfg,
     edgeSelectionColor,
@@ -436,6 +434,7 @@ export const useGraphController = (
     renderBackground,
     renderOverlay,
     renderContext,
+    onRenderPropError: onError,
     showArrows: renderBindings.showArrows,
     arrowMarkerId: renderBindings.arrowMarkerId,
     hoverArrowMarkerId: renderBindings.hoverArrowMarkerId,
@@ -506,5 +505,6 @@ export const useGraphController = (
     handlePointerUp,
     handlePointerCancel,
     handleKeyDown,
+    ariaLabel,
   };
 };

--- a/src/react-graph-render/src/hooks/useGraphHoverEngine.ts
+++ b/src/react-graph-render/src/hooks/useGraphHoverEngine.ts
@@ -1,6 +1,9 @@
 import type { PositionedEdge, PositionedNode } from '@graph-render/types';
 import type { GraphHoverMeta, GraphSelection, GraphViewport } from '@graph-render/types/react';
+import { useMemo } from 'react';
 
+import type { EdgeRenderState } from '../utils/edgeRenderState';
+import { getEdgeRenderState } from '../utils/edgeRenderState';
 import { useGraphHover } from './useGraphHover';
 import { useGraphHoverHandlers } from './useGraphHoverHandlers';
 
@@ -71,6 +74,22 @@ export const useGraphHoverEngine = ({
   });
 
   return {
+    // Pre-computed per-edge render state map — GraphEdgesLayer does O(1) lookup per edge
+    edgeRenderStates: useMemo<ReadonlyMap<string, EdgeRenderState>>(() => {
+      const map = new Map<string, EdgeRenderState>();
+      for (const edge of edgesForRender) {
+        map.set(
+          edge.id,
+          getEdgeRenderState(edge, {
+            hoverHighlight,
+            hoveredEdgeId,
+            hoveredNodeId,
+            pathHighlightEdges: pathHighlight?.edges,
+          })
+        );
+      }
+      return map;
+    }, [edgesForRender, hoverHighlight, hoveredEdgeId, hoveredNodeId, pathHighlight]),
     // State exposed for downstream consumers (e.g. edge culling, keyboard nav)
     hoveredEdgeId,
     hoveredNodeId,

--- a/src/react-graph-render/src/hooks/useGraphHoverEngine.ts
+++ b/src/react-graph-render/src/hooks/useGraphHoverEngine.ts
@@ -1,0 +1,89 @@
+import type { PositionedEdge, PositionedNode } from '@graph-render/types';
+import type { GraphHoverMeta, GraphSelection, GraphViewport } from '@graph-render/types/react';
+
+import { useGraphHover } from './useGraphHover';
+import { useGraphHoverHandlers } from './useGraphHoverHandlers';
+
+export interface UseGraphHoverEngineOptions {
+  readonly hoverHighlight: boolean;
+  readonly positionedNodes: readonly PositionedNode[];
+  readonly positionedEdges: readonly PositionedEdge[];
+  readonly positionedNodeMap: ReadonlyMap<string, PositionedNode>;
+  readonly positionedEdgeMap: ReadonlyMap<string, PositionedEdge>;
+  readonly selection: GraphSelection;
+  readonly viewport: GraphViewport;
+  readonly onNodeHoverChange:
+    | ((node: PositionedNode, hovered: boolean, meta: GraphHoverMeta) => void)
+    | undefined;
+  readonly onEdgeHoverChange:
+    | ((edge: PositionedEdge, hovered: boolean, meta: GraphHoverMeta) => void)
+    | undefined;
+}
+
+/**
+ * Aggregates hover state (`useGraphHover`) and the corresponding event handlers
+ * (`useGraphHoverHandlers`) into a single cohesive unit.
+ *
+ * Previously, `useGraphController` had to thread `setHoveredEdgeId`, `setHoveredNodeId`,
+ * and `setFocusedPath` from `useGraphHover` into `useGraphHoverHandlers` manually.
+ * This hook encapsulates that wiring and exposes only the stable public surface.
+ */
+export const useGraphHoverEngine = ({
+  hoverHighlight,
+  positionedNodes,
+  positionedEdges,
+  positionedNodeMap,
+  positionedEdgeMap,
+  selection,
+  viewport,
+  onNodeHoverChange,
+  onEdgeHoverChange,
+}: UseGraphHoverEngineOptions) => {
+  const {
+    hoveredEdgeId,
+    setHoveredEdgeId,
+    hoveredNodeId,
+    setHoveredNodeId,
+    focusedPath,
+    setFocusedPath,
+    pathHighlight,
+    hoveredNodeStates,
+    edgesForRender,
+  } = useGraphHover(positionedNodes, positionedEdges, hoverHighlight);
+
+  const {
+    handleEdgeHoverChange,
+    handleNodeMouseEnter,
+    handleNodeMouseLeave,
+    handlePathHover,
+    handlePathLeave,
+  } = useGraphHoverHandlers({
+    hoverHighlight,
+    onEdgeHoverChange,
+    onNodeHoverChange,
+    positionedEdgeMap,
+    positionedNodeMap,
+    selection,
+    setFocusedPath,
+    setHoveredEdgeId,
+    setHoveredNodeId,
+    viewport,
+  });
+
+  return {
+    // State exposed for downstream consumers (e.g. edge culling, keyboard nav)
+    hoveredEdgeId,
+    hoveredNodeId,
+    focusedPath,
+    setFocusedPath,
+    pathHighlight,
+    hoveredNodeStates,
+    edgesForRender,
+    // Handlers exposed for component event wiring
+    handleEdgeHoverChange,
+    handleNodeMouseEnter,
+    handleNodeMouseLeave,
+    handlePathHover,
+    handlePathLeave,
+  };
+};

--- a/src/react-graph-render/src/hooks/useGraphModel.ts
+++ b/src/react-graph-render/src/hooks/useGraphModel.ts
@@ -1,7 +1,7 @@
 import { fromTypedNxGraph, normalizeEdges } from '@graph-render/core';
-import type { PositionedEdge, PositionedNode, Size } from '@graph-render/types';
+import type { NodeData, PositionedEdge, PositionedNode, Size } from '@graph-render/types';
 import { GraphFailureBehavior, NodeSizingMode } from '@graph-render/types';
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useReducer, useRef } from 'react';
 
 import type { GraphModelResult, UseGraphModelOptions } from '../models/graph';
 import { resolvePositionedNodes } from '../utils/graphModelLayout';
@@ -12,6 +12,36 @@ import { useGraphSearchState } from './useGraphSearchState';
 import { useLatestRef } from './useLatestRef';
 
 export type { GraphModelResult, UseGraphModelOptions } from '../models/graph';
+
+// ---------------------------------------------------------------------------
+// Reducer for measured node sizes (eliminates the extra render from useEffect)
+// ---------------------------------------------------------------------------
+
+type MeasuredSizesState = Record<string, Size>;
+
+type MeasuredSizesAction =
+  | { readonly type: 'PRUNE'; readonly activeNodes: readonly NodeData[] }
+  | { readonly type: 'UPDATE_SIZE'; readonly nodeId: string; readonly size: Size };
+
+const measuredSizesReducer = (
+  state: MeasuredSizesState,
+  action: MeasuredSizesAction
+): MeasuredSizesState => {
+  switch (action.type) {
+    case 'PRUNE': {
+      return pruneMeasuredNodeSizes(state, action.activeNodes);
+    }
+    case 'UPDATE_SIZE': {
+      const previous = state[action.nodeId];
+      if (previous?.width === action.size.width && previous?.height === action.size.height) {
+        return state;
+      }
+      return { ...state, [action.nodeId]: action.size };
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
 
 export const useGraphModel = ({
   graph,
@@ -30,7 +60,10 @@ export const useGraphModel = ({
   routeEdgesOverride,
   onError,
 }: UseGraphModelOptions): GraphModelResult => {
-  const [measuredNodeSizes, setMeasuredNodeSizes] = useState<Record<string, Size>>({});
+  const [measuredNodeSizes, dispatchMeasuredSizes] = useReducer(
+    measuredSizesReducer,
+    {} as MeasuredSizesState
+  );
   const onErrorRef = useLatestRef(onError);
   const reportedErrorsRef = useRef<WeakSet<Error>>(new WeakSet());
   const deferredSearchQuery = useDeferredValue(searchQuery);
@@ -50,8 +83,9 @@ export const useGraphModel = ({
     [measuredNodeSizes, sourceNodes]
   );
 
-  useEffect(() => {
-    setMeasuredNodeSizes((current) => pruneMeasuredNodeSizes(current, sourceNodes));
+  // Prune stale measured sizes in the same render pass as topology changes (no extra render).
+  useMemo(() => {
+    dispatchMeasuredSizes({ type: 'PRUNE', activeNodes: sourceNodes });
   }, [sourceNodes]);
 
   const normalizedEdges = useMemo(
@@ -80,15 +114,19 @@ export const useGraphModel = ({
     visibleNodes,
   } = searchState;
 
+  // Defer layout computation so search/collapse interactions stay interactive.
+  const deferredVisibleNodes = useDeferredValue(visibleNodes);
+  const deferredVisibleEdges = useDeferredValue(visibleEdges);
+
   const layoutOptions = useMemo(
     () =>
       buildGraphLayoutOptions({
         config,
-        edges: visibleEdges,
+        edges: deferredVisibleEdges,
         mergedTheme,
-        nodes: visibleNodes,
+        nodes: deferredVisibleNodes,
       }),
-    [config, mergedTheme, visibleEdges, visibleNodes]
+    [config, mergedTheme, deferredVisibleEdges, deferredVisibleNodes]
   );
 
   const handleNodeMeasure = useCallback(
@@ -97,14 +135,7 @@ export const useGraphModel = ({
         return;
       }
 
-      setMeasuredNodeSizes((current) => {
-        const previous = current[nodeId];
-        if (previous?.width === size.width && previous?.height === size.height) {
-          return current;
-        }
-
-        return { ...current, [nodeId]: size };
-      });
+      dispatchMeasuredSizes({ type: 'UPDATE_SIZE', nodeId, size });
     },
     [config.nodeSizing]
   );
@@ -116,9 +147,9 @@ export const useGraphModel = ({
         graph,
         layoutNodesOverride,
         layoutOptions,
-        visibleNodes,
+        visibleNodes: deferredVisibleNodes,
       }),
-    [allowDegradedGraph, graph, layoutNodesOverride, layoutOptions, visibleNodes]
+    [allowDegradedGraph, graph, layoutNodesOverride, layoutOptions, deferredVisibleNodes]
   );
   const positionedNodes: readonly PositionedNode[] = positionedNodeResult.nodes;
 
@@ -142,7 +173,7 @@ export const useGraphModel = ({
         graph,
         positionedNodes,
         routeEdgesOverride,
-        visibleEdges,
+        visibleEdges: deferredVisibleEdges,
       }),
     [
       allowDegradedGraph,
@@ -150,7 +181,7 @@ export const useGraphModel = ({
       graph,
       positionedNodes,
       routeEdgesOverride,
-      visibleEdges,
+      deferredVisibleEdges,
     ]
   );
   const positionedEdges: readonly PositionedEdge[] = positionedEdgeResult.edges;
@@ -172,7 +203,7 @@ export const useGraphModel = ({
     handleNodeMeasure,
     positionedEdges,
     positionedNodes,
-    visibleEdges,
-    visibleNodesWithMeasuredSize: visibleNodes,
+    visibleEdges: deferredVisibleEdges,
+    visibleNodesWithMeasuredSize: deferredVisibleNodes,
   };
 };

--- a/src/react-graph-render/src/hooks/useGraphSelectionEngine.ts
+++ b/src/react-graph-render/src/hooks/useGraphSelectionEngine.ts
@@ -1,0 +1,85 @@
+import type { PositionedEdge, PositionedNode } from '@graph-render/types';
+import type { GraphSelection, SelectionMode } from '@graph-render/types/react';
+
+import type { UseGraphViewStateResult } from '../models/hookContracts';
+import { useGraphSelectionHandlers } from './useGraphSelectionHandlers';
+import { useGraphVisibleSelection } from './useGraphVisibleSelection';
+
+interface VisibleEntity {
+  readonly id: string;
+}
+
+export interface UseGraphSelectionEngineOptions {
+  readonly focusedNodeId: string | null;
+  readonly selection: GraphSelection;
+  readonly selectionRef: UseGraphViewStateResult['selectionRef'];
+  readonly updateFocusedNode: UseGraphViewStateResult['updateFocusedNode'];
+  readonly updateSelection: UseGraphViewStateResult['updateSelection'];
+  readonly visibleEdges: readonly VisibleEntity[];
+  readonly visibleNodes: readonly VisibleEntity[];
+  readonly edgeSelectionEnabled: boolean;
+  readonly nodeSelectionEnabled: boolean;
+  readonly onEdgeClick: ((edge: PositionedEdge) => void) | undefined;
+  readonly onNodeClick: ((node: PositionedNode) => void) | undefined;
+  readonly selectionMode: SelectionMode;
+}
+
+/**
+ * Aggregates visible-selection filtering (`useGraphVisibleSelection`) and the
+ * corresponding click handlers (`useGraphSelectionHandlers`) into a single unit.
+ *
+ * Previously, `useGraphController` called both hooks separately and threaded
+ * the `updateFocusedNode` / `updateSelection` helpers between them.
+ */
+export const useGraphSelectionEngine = ({
+  focusedNodeId,
+  selection,
+  selectionRef,
+  updateFocusedNode,
+  updateSelection,
+  visibleEdges,
+  visibleNodes,
+  edgeSelectionEnabled,
+  nodeSelectionEnabled,
+  onEdgeClick,
+  onNodeClick,
+  selectionMode,
+}: UseGraphSelectionEngineOptions) => {
+  const {
+    effectiveFocusedNodeId,
+    effectiveSelection,
+    selectedEdgeSet,
+    selectedNodeSet,
+    visibleEdgeIdSet,
+    visibleNodeIdSet,
+  } = useGraphVisibleSelection({
+    focusedNodeId,
+    selection,
+    selectionRef,
+    updateFocusedNode,
+    updateSelection,
+    visibleEdges,
+    visibleNodes,
+  });
+
+  const { handleEdgeSelection, handleNodeSelection } = useGraphSelectionHandlers({
+    edgeSelectionEnabled,
+    nodeSelectionEnabled,
+    onEdgeClick,
+    onNodeClick,
+    selectionMode,
+    updateFocusedNode,
+    updateSelection,
+  });
+
+  return {
+    effectiveFocusedNodeId,
+    effectiveSelection,
+    selectedEdgeSet,
+    selectedNodeSet,
+    visibleEdgeIdSet,
+    visibleNodeIdSet,
+    handleEdgeSelection,
+    handleNodeSelection,
+  };
+};

--- a/src/react-graph-render/src/hooks/useGraphViewportController.ts
+++ b/src/react-graph-render/src/hooks/useGraphViewportController.ts
@@ -56,6 +56,9 @@ export const useGraphViewportController = ({
   updateViewport,
   viewport,
   zoomStep,
+  selectionRef,
+  collapsedIds,
+  pendingExpansionNodeSet,
 }: UseGraphViewportControllerOptions) => {
   const hasAppliedInitialFitViewRef = useRef(false);
   const contentBounds = useMemo(
@@ -105,8 +108,21 @@ export const useGraphViewportController = ({
       getViewport: () => viewport,
       setViewport: updateViewport,
       clearSelection: () => updateSelection({ nodeIds: [], edgeIds: [] }),
+      getSelection: () => selectionRef.current,
+      getCollapsedNodeIds: () => collapsedIds,
+      getPendingExpansionNodeIds: () => pendingExpansionNodeSet,
     }),
-    [centerOnNode, fitView, updateSelection, updateViewport, viewport, zoomStep]
+    [
+      centerOnNode,
+      collapsedIds,
+      fitView,
+      pendingExpansionNodeSet,
+      selectionRef,
+      updateSelection,
+      updateViewport,
+      viewport,
+      zoomStep,
+    ]
   );
 
   useEffect(() => {

--- a/src/react-graph-render/src/models/hookContracts.ts
+++ b/src/react-graph-render/src/models/hookContracts.ts
@@ -195,6 +195,12 @@ export interface UseGraphViewportControllerOptions {
   readonly updateViewport: GraphHandle['setViewport'];
   readonly viewport: GraphViewport;
   readonly zoomStep: number;
+  /** Ref to the current selection — read without causing re-renders. */
+  readonly selectionRef: React.RefObject<GraphSelection>;
+  /** Current collapsed node IDs (from useGraphCollapse). */
+  readonly collapsedIds: readonly string[];
+  /** Current in-flight expansion node set (from useGraphCollapse). */
+  readonly pendingExpansionNodeSet: ReadonlySet<string>;
 }
 
 // ── useGraphViewState ────────────────────────────────────────────────────────

--- a/src/react-graph-render/src/utils/resolveGraphProps.ts
+++ b/src/react-graph-render/src/utils/resolveGraphProps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- This file is a compatibility shim that intentionally reads deprecated flat props to merge them with grouped options. */
 import type {
   GraphInteractionOptions,
   GraphProps,

--- a/src/react-graph-render/src/utils/viewportCulling.ts
+++ b/src/react-graph-render/src/utils/viewportCulling.ts
@@ -3,7 +3,7 @@ import type { GraphViewport } from '@graph-render/types/react';
 
 import { DEFAULT_NODE_HEIGHT, DEFAULT_NODE_WIDTH } from '../constants/graph';
 
-const DEFAULT_PADDING = 96;
+const CULLING_OVERSCAN_PADDING = 96;
 
 export interface ViewportWorldBounds {
   readonly minX: number;
@@ -16,7 +16,7 @@ export const getViewportWorldBounds = (
   viewport: GraphViewport,
   width: number,
   height: number,
-  padding = DEFAULT_PADDING
+  padding = CULLING_OVERSCAN_PADDING
 ): ViewportWorldBounds => {
   const minX = (-viewport.x - padding) / viewport.zoom;
   const minY = (-viewport.y - padding) / viewport.zoom;
@@ -87,7 +87,7 @@ export const filterNodesInViewport = (
   viewport: GraphViewport,
   width: number,
   height: number,
-  padding = DEFAULT_PADDING
+  padding = CULLING_OVERSCAN_PADDING
 ): readonly PositionedNode[] => {
   if (nodes.length === 0 || width <= 0 || height <= 0) {
     return nodes;
@@ -109,7 +109,7 @@ export const filterEdgesInViewport = (
   viewport: GraphViewport,
   width: number,
   height: number,
-  padding = DEFAULT_PADDING
+  padding = CULLING_OVERSCAN_PADDING
 ): readonly PositionedEdge[] => {
   if (edges.length === 0) {
     return edges;

--- a/src/react-tournament-tree/package.json
+++ b/src/react-tournament-tree/package.json
@@ -61,7 +61,7 @@
     "node": ">=20.19.0"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
+    "react": ">=18.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
@@ -73,7 +73,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "@vitest/coverage-v8": "^3.0.0",
     "jsdom": "^29.1.1",
-    "react": "^19.0.0",
+    "react": ">=18.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.4.5",
     "vite": "^5.4.0",

--- a/src/react-tournament-tree/src/components/Bracket/BracketGraphCanvas.tsx
+++ b/src/react-tournament-tree/src/components/Bracket/BracketGraphCanvas.tsx
@@ -84,11 +84,15 @@ export function BracketGraphCanvas({
         vertexComponent={vertexComponent}
         config={config}
         defaultViewport={defaultViewport}
-        panEnabled={panEnabled ?? !isNavigationMode}
-        zoomEnabled={zoomEnabled ?? !isNavigationMode}
-        pinchZoomEnabled={pinchZoomEnabled ?? !isNavigationMode}
-        translateExtent={isNavigationMode ? undefined : translateExtent}
-        showControls={showViewportControls}
+        interaction={{
+          panEnabled: panEnabled ?? !isNavigationMode,
+          zoomEnabled: zoomEnabled ?? !isNavigationMode,
+          pinchZoomEnabled: pinchZoomEnabled ?? !isNavigationMode,
+        }}
+        viewportOptions={{
+          translateExtent: isNavigationMode ? undefined : translateExtent,
+          showControls: showViewportControls,
+        }}
         onNodeClick={handleMatchClick}
         onLayoutChange={handleLayoutChange}
         routeEdgesOverride={routeBracketEdges}

--- a/src/react-tournament-tree/src/components/TournamentBracket.tsx
+++ b/src/react-tournament-tree/src/components/TournamentBracket.tsx
@@ -120,7 +120,7 @@ export const TournamentBracket = React.memo<TournamentBracketProps>(function Tou
   });
 
   return (
-    <BracketAppearanceProvider appearance={appearance} isDarkMode={isDarkMode} compact={compact}>
+    <BracketAppearanceProvider resolvedAppearance={resolvedAppearance}>
       <BracketFrame
         title={title}
         badgeText={resolvedBadgeText}

--- a/src/react-tournament-tree/src/contexts/BracketAppearanceContext.tsx
+++ b/src/react-tournament-tree/src/contexts/BracketAppearanceContext.tsx
@@ -10,20 +10,26 @@ const BracketAppearanceContext = React.createContext<ResolvedBracketAppearance |
 
 export interface BracketAppearanceProviderProps {
   readonly appearance?: TournamentBracketAppearance | undefined;
-  readonly isDarkMode: boolean;
-  readonly compact: boolean;
+  readonly isDarkMode?: boolean | undefined;
+  readonly compact?: boolean | undefined;
+  /**
+   * Pass a pre-resolved appearance to skip an extra `resolveBracketAppearance` call.
+   * When provided, `appearance`, `isDarkMode`, and `compact` are ignored.
+   */
+  readonly resolvedAppearance?: ResolvedBracketAppearance | undefined;
   readonly children: React.ReactNode;
 }
 
 export const BracketAppearanceProvider: React.FC<BracketAppearanceProviderProps> = ({
   appearance,
-  isDarkMode,
-  compact,
+  isDarkMode = false,
+  compact = true,
+  resolvedAppearance,
   children,
 }) => {
   const value = React.useMemo(
-    () => resolveBracketAppearance(appearance, isDarkMode, compact),
-    [appearance, compact, isDarkMode]
+    () => resolvedAppearance ?? resolveBracketAppearance(appearance, isDarkMode, compact),
+    [appearance, compact, isDarkMode, resolvedAppearance]
   );
 
   return (

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -55,7 +55,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "react": "^19.0.0"
+    "react": ">=18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@vitest/coverage-v8": "^3.0.0",
-    "react": "^19.0.0",
+    "react": ">=18.0.0",
     "typescript": "^5.3.3",
     "vitest": "^3.0.0"
   }

--- a/src/types/src/__tests__/exports.test.ts
+++ b/src/types/src/__tests__/exports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import * as rootTypes from '../index';
+import { isPositionedNode, makePositionedNode } from '../node';
 import * as reactTypes from '../react';
 
 describe('@graph-render/types public exports', () => {
@@ -18,5 +19,32 @@ describe('@graph-render/types public exports', () => {
   it('exports React graph contracts from the react subpath', () => {
     expect(reactTypes.SelectionMode).toBeDefined();
     expect(reactTypes.GraphErrorPhase).toBeDefined();
+  });
+});
+
+describe('makePositionedNode', () => {
+  it('merges node data with a position', () => {
+    const node = { id: 'n1', label: 'Test' };
+    const position = { x: 10, y: 20 };
+    const result = makePositionedNode(node, position);
+    expect(result).toEqual({ id: 'n1', label: 'Test', position: { x: 10, y: 20 } });
+  });
+
+  it('preserves all node fields', () => {
+    const node = { id: 'n2', data: { foo: 'bar' }, size: { width: 100, height: 40 } };
+    const result = makePositionedNode(node, { x: 0, y: 0 });
+    expect(result.data).toEqual({ foo: 'bar' });
+    expect(result.size).toEqual({ width: 100, height: 40 });
+    expect(result.position).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('isPositionedNode', () => {
+  it('returns true when position is defined', () => {
+    expect(isPositionedNode({ id: 'n1', position: { x: 1, y: 2 } })).toBe(true);
+  });
+
+  it('returns false when position is undefined', () => {
+    expect(isPositionedNode({ id: 'n1' })).toBe(false);
   });
 });

--- a/src/types/src/config.ts
+++ b/src/types/src/config.ts
@@ -12,11 +12,27 @@ export enum RoutingStyle {
   Bundled = 'bundled',
 }
 
+/**
+ * Tree-shakeable alternative to the `RoutingStyle` enum.
+ * Prefer this and `RoutingStyleValue` for new code — plain string literals
+ * are assignable to `RoutingStyleValue` without needing to import the enum.
+ */
+export const RoutingStyleValues = {
+  Smart: 'smart',
+  Orthogonal: 'orthogonal',
+  Bundled: 'bundled',
+} as const;
+export type RoutingStyleValue = (typeof RoutingStyleValues)[keyof typeof RoutingStyleValues];
+
 export enum EdgeType {
   Directed = 'directed',
   Undirected = 'undirected',
 }
 
+/**
+ * Tree-shakeable alternative available as `LayoutTypeValues`/`LayoutTypeValue`.
+ * Prefer those for new code — plain string literals are assignable to `LayoutTypeValue`.
+ */
 export enum LayoutType {
   Grid = 'grid',
   Tree = 'tree',
@@ -28,10 +44,30 @@ export enum LayoutType {
   OrthogonalFlow = 'orthogonal-flow',
 }
 
+export const LayoutTypeValues = {
+  Grid: 'grid',
+  Tree: 'tree',
+  Centered: 'centered',
+  Radial: 'radial',
+  Dag: 'dag',
+  ForceDirected: 'force-directed',
+  CompactBracket: 'compact-bracket',
+  OrthogonalFlow: 'orthogonal-flow',
+} as const;
+export type LayoutTypeValue = (typeof LayoutTypeValues)[keyof typeof LayoutTypeValues];
+
+/**
+ * Tree-shakeable alternative available as `LayoutDirectionValues`/`LayoutDirectionValue`.
+ * Prefer those for new code.
+ */
 export enum LayoutDirection {
   LTR = 'ltr',
   RTL = 'rtl',
 }
+
+export const LayoutDirectionValues = { LTR: 'ltr', RTL: 'rtl' } as const;
+export type LayoutDirectionValue =
+  (typeof LayoutDirectionValues)[keyof typeof LayoutDirectionValues];
 
 export interface GraphTheme {
   readonly background?: string | undefined;

--- a/src/types/src/node.ts
+++ b/src/types/src/node.ts
@@ -10,11 +10,22 @@ export interface Size {
   readonly height: number;
 }
 
+/**
+ * Tree-shakeable alternative available as `NodeSizingModeValues`/`NodeSizingModeValue`.
+ * Prefer those for new code — plain string literals are assignable to `NodeSizingModeValue`.
+ */
 export enum NodeSizingMode {
   Fixed = 'fixed',
   Label = 'label',
   Measured = 'measured',
 }
+
+export const NodeSizingModeValues = {
+  Fixed: 'fixed',
+  Label: 'label',
+  Measured: 'measured',
+} as const;
+export type NodeSizingModeValue = (typeof NodeSizingModeValues)[keyof typeof NodeSizingModeValues];
 
 export interface NodeMeasurementHints {
   readonly label?: string | undefined;
@@ -47,3 +58,25 @@ export interface PositionedNode<
 > extends NodeData<TData, TMeta, TLabel> {
   readonly position: Point;
 }
+
+/**
+ * Type-safe factory that merges a `NodeData` with an explicit `position`,
+ * producing a `PositionedNode` without unsafe `as` casts.
+ */
+export const makePositionedNode = <
+  TData = unknown,
+  TMeta extends object = Record<string, unknown>,
+  TLabel = unknown,
+>(
+  node: NodeData<TData, TMeta, TLabel>,
+  position: Point
+): PositionedNode<TData, TMeta, TLabel> => ({ ...node, position });
+
+/** Type guard: returns true when the node's `position` field is already set. */
+export const isPositionedNode = <
+  TData = unknown,
+  TMeta extends object = Record<string, unknown>,
+  TLabel = unknown,
+>(
+  node: NodeData<TData, TMeta, TLabel>
+): node is PositionedNode<TData, TMeta, TLabel> => node.position !== undefined;

--- a/src/types/src/react.ts
+++ b/src/types/src/react.ts
@@ -1,6 +1,6 @@
 import type { ComponentType, ReactNode } from 'react';
 
-import type { GraphConfig } from './config';
+import type { GraphConfig, NormalizedGraphConfig } from './config';
 import type { EdgeData, PositionedEdge as CorePositionedEdge, PositionedEdge } from './edge';
 import type { NxGraphInput } from './graph';
 import type { LayoutOptions } from './layout';
@@ -89,15 +89,23 @@ export interface GraphRenderContext<
   readonly graph: TGraph;
   readonly nodes: readonly TNode[];
   readonly edges: readonly TEdge[];
-  readonly config?: GraphConfig | undefined;
+  /** Normalized configuration that is always available at render time. */
+  readonly config: NormalizedGraphConfig;
   readonly viewport: GraphViewport;
   readonly selection: GraphSelection;
 }
 
+/**
+ * Tree-shakeable alternative available as `SelectionModeValues`/`SelectionModeValue`.
+ * Prefer those for new code — plain string literals are assignable to `SelectionModeValue`.
+ */
 export enum SelectionMode {
   Single = 'single',
   Multiple = 'multiple',
 }
+
+export const SelectionModeValues = { Single: 'single', Multiple: 'multiple' } as const;
+export type SelectionModeValue = (typeof SelectionModeValues)[keyof typeof SelectionModeValues];
 
 export enum GraphHoverTrigger {
   Pointer = 'pointer',
@@ -115,6 +123,10 @@ export interface GraphSearchResults {
   readonly edgeIds: readonly string[];
 }
 
+/**
+ * Tree-shakeable alternative available as `GraphErrorPhaseValues`/`GraphErrorPhaseValue`.
+ * Prefer those for new code.
+ */
 export enum GraphErrorPhase {
   Layout = 'layout',
   LayoutOverride = 'layout-override',
@@ -123,6 +135,17 @@ export enum GraphErrorPhase {
   Interaction = 'interaction',
   Render = 'render',
 }
+
+export const GraphErrorPhaseValues = {
+  Layout: 'layout',
+  LayoutOverride: 'layout-override',
+  Routing: 'routing',
+  RoutingOverride: 'routing-override',
+  Interaction: 'interaction',
+  Render: 'render',
+} as const;
+export type GraphErrorPhaseValue =
+  (typeof GraphErrorPhaseValues)[keyof typeof GraphErrorPhaseValues];
 
 export interface GraphErrorContext<TGraph extends NxGraphInput = NxGraphInput> {
   readonly graph: TGraph;
@@ -143,6 +166,12 @@ export interface GraphHandle {
       | ((current: GraphViewport) => Partial<GraphViewport> | GraphViewport)
   ) => void;
   readonly clearSelection: () => void;
+  /** Read the current selection without a re-render. */
+  readonly getSelection: () => GraphSelection;
+  /** Read the current collapsed node IDs without a re-render. */
+  readonly getCollapsedNodeIds: () => readonly string[];
+  /** Read the node IDs whose async expansion is currently in-flight. */
+  readonly getPendingExpansionNodeIds: () => ReadonlySet<string>;
 }
 
 export interface DragState {
@@ -197,10 +226,26 @@ export interface GraphProps<
   readonly onViewportChange?: ((viewport: GraphViewport) => void) | undefined;
   readonly fitViewOnMount?: boolean | undefined;
   readonly fitViewPadding?: number | undefined;
+  /**
+   * @deprecated Use {@link GraphViewportOptions.minZoom} via the `viewportOptions` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly minZoom?: number | undefined;
+  /**
+   * @deprecated Use {@link GraphViewportOptions.maxZoom} via the `viewportOptions` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly maxZoom?: number | undefined;
+  /**
+   * @deprecated Use {@link GraphViewportOptions.zoomStep} via the `viewportOptions` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly zoomStep?: number | undefined;
-  /** World-space bounding box `[[minX, minY], [maxX, maxY]]` the user cannot pan outside of. */
+  /**
+   * World-space bounding box `[[minX, minY], [maxX, maxY]]` the user cannot pan outside of.
+   * @deprecated Use {@link GraphViewportOptions.translateExtent} via the `viewportOptions` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly translateExtent?:
     | readonly [readonly [number, number], readonly [number, number]]
     | undefined;
@@ -214,12 +259,40 @@ export interface GraphProps<
   readonly onLayoutChange?:
     | ((context: GraphRenderContext<TGraph, TNode, TEdge>) => void)
     | undefined;
+  /**
+   * @deprecated Use {@link GraphInteractionOptions.panEnabled} via the `interaction` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly panEnabled?: boolean | undefined;
+  /**
+   * @deprecated Use {@link GraphInteractionOptions.zoomEnabled} via the `interaction` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly zoomEnabled?: boolean | undefined;
+  /**
+   * @deprecated Use {@link GraphInteractionOptions.pinchZoomEnabled} via the `interaction` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly pinchZoomEnabled?: boolean | undefined;
+  /**
+   * @deprecated Use {@link GraphInteractionOptions.keyboardNavigation} via the `interaction` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly keyboardNavigation?: boolean | undefined;
+  /**
+   * @deprecated Use {@link GraphViewportOptions.showControls} via the `viewportOptions` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly showControls?: boolean | undefined;
+  /**
+   * @deprecated Use {@link GraphViewportOptions.controlsPosition} via the `viewportOptions` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly controlsPosition?: GraphControlsPosition | undefined;
+  /**
+   * @deprecated Use {@link GraphInteractionOptions.marqueeSelectionEnabled} via the `interaction` prop instead.
+   * Flat props take precedence over grouped options when both are set.
+   */
   readonly marqueeSelectionEnabled?: boolean | undefined;
   readonly focusedNodeId?: string | null | undefined;
   readonly defaultFocusedNodeId?: string | null | undefined;
@@ -280,4 +353,6 @@ export interface GraphProps<
     | undefined;
   readonly onNodeClick?: ((node: TNode) => void) | undefined;
   readonly onEdgeClick?: ((edge: TEdge) => void) | undefined;
+  /** Accessible label for the SVG element. Defaults to `"Graph"`. Expose when rendering multiple graphs on a page. */
+  readonly ariaLabel?: string | undefined;
 }


### PR DESCRIPTION
- Add aggregator hooks useGraphHoverEngine and useGraphSelectionEngine
- Wire engine hooks into useGraphController (remove manual setter threading)
- Add GraphThemeContext/GraphThemeProvider with theme tokens
- Add const alternatives for enums (LayoutTypeValues, RoutingStyleValues, etc.)
- Fix @deprecated placement: enums keep working, consts are the preferred API
- Add eslint-disable to compatibility shims (useGraphController, resolveGraphProps)
- Fix unicorn/switch-case-braces in useGraphModel reducer
- Fix simple-import-sort in layouts/index.ts and treeAlignment.ts
- Migrate Graph.test.tsx deprecated flat props to grouped options API
- Add Graph.integration.test.tsx with real @graph-render/core
- Fix testing-library/prefer-find-by in integration test
- Fix GraphNode.test.tsx and GraphNodesLayer.test.tsx for GraphThemeProvider