### PR TITLE
fix: add render_with_liquid: false to AGENTS.md to fix Jekyll build

### DIFF
--- a/docs/internal/AGENTS.md
+++ b/docs/internal/AGENTS.md
@@ -1,3 +1,7 @@
+---
+render_with_liquid: false
+---
+
 # React Best Practices
 
 **Version 1.0.0**  


### PR DESCRIPTION
The file contains JSX code with {{ which Liquid tries to parse as template variables, causing a Liquid::SyntaxError during GitHub Pages deployment.