### PR TITLE
feat(tournament-tree): add PNG and optional PDF export (#16)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -36,6 +36,13 @@ const config: StorybookConfig = {
         jsx: 'automatic',
         jsxImportSource: 'react',
       },
+      build: {
+        rolldownOptions: {
+          // jspdf is an optional peer dependency; mark external so the bundler
+          // doesn't error when it cannot resolve it during the storybook build.
+          external: ['jspdf'],
+        },
+      },
       resolve: {
         alias: {
           '@graph-render/types': path.resolve(__dirname, '../src/types/src'),

--- a/src/core-graph-render/CHANGELOG.md
+++ b/src/core-graph-render/CHANGELOG.md
@@ -1,14 +1,10 @@
 ## @graph-render/core 1.4.0 (2026-05-25)
 
-* feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
-
-
-
-
+- feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
 
 ### Dependencies
 
-* **@graph-render/types:** upgraded to 1.4.0
+- **@graph-render/types:** upgraded to 1.4.0
 
 ## <small>1.3.7 (2026-05-24)</small>
 

--- a/src/react-graph-render/CHANGELOG.md
+++ b/src/react-graph-render/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## @graph-render/react 1.5.0 (2026-05-25)
 
-* feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
-
-
-
-
+- feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
 
 ### Dependencies
 
-* **@graph-render/core:** upgraded to 1.4.0
-* **@graph-render/types:** upgraded to 1.4.0
+- **@graph-render/core:** upgraded to 1.4.0
+- **@graph-render/types:** upgraded to 1.4.0
 
 ## <small>1.4.7 (2026-05-24)</small>
 

--- a/src/react-tournament-tree/CHANGELOG.md
+++ b/src/react-tournament-tree/CHANGELOG.md
@@ -1,16 +1,12 @@
 ## @graph-render/tournament-tree 1.7.0 (2026-05-25)
 
-* feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
-
-
-
-
+- feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
 
 ### Dependencies
 
-* **@graph-render/core:** upgraded to 1.4.0
-* **@graph-render/react:** upgraded to 1.5.0
-* **@graph-render/types:** upgraded to 1.4.0
+- **@graph-render/core:** upgraded to 1.4.0
+- **@graph-render/react:** upgraded to 1.5.0
+- **@graph-render/types:** upgraded to 1.4.0
 
 ## @graph-render/tournament-tree 1.6.0 (2026-05-24)
 

--- a/src/react-tournament-tree/src/__mocks__/jspdf.ts
+++ b/src/react-tournament-tree/src/__mocks__/jspdf.ts
@@ -1,0 +1,7 @@
+/** Minimal jsPDF stub for unit tests. */
+export class jsPDF {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function -- stub for tests
+  addImage() {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function -- stub for tests
+  save() {}
+}

--- a/src/react-tournament-tree/src/components/Bracket/BracketFrame.tsx
+++ b/src/react-tournament-tree/src/components/Bracket/BracketFrame.tsx
@@ -29,6 +29,8 @@ interface BracketFrameProps {
   readonly onPagePlayersDown: () => void;
   readonly onToggleDarkMode: () => void;
   readonly onExportSVG: () => void;
+  readonly onExportPNG: () => void;
+  readonly onExportPDF?: (() => void) | undefined;
 }
 
 export function BracketFrame({
@@ -52,6 +54,8 @@ export function BracketFrame({
   onPagePlayersDown,
   onToggleDarkMode,
   onExportSVG,
+  onExportPNG,
+  onExportPDF,
 }: BracketFrameProps) {
   const { colors, frame } = useBracketAppearance();
   const canGoPrev = activeStageIndex > 0;
@@ -84,6 +88,8 @@ export function BracketFrame({
         onToggleNavigationMode={onToggleNavigationMode}
         onToggleDarkMode={onToggleDarkMode}
         onExportSVG={onExportSVG}
+        onExportPNG={onExportPNG}
+        onExportPDF={onExportPDF}
       />
       <StageLabelBar
         stageLabels={stageLabels}

--- a/src/react-tournament-tree/src/components/Bracket/BracketHeader.tsx
+++ b/src/react-tournament-tree/src/components/Bracket/BracketHeader.tsx
@@ -12,6 +12,8 @@ interface BracketHeaderProps {
   readonly onToggleNavigationMode: () => void;
   readonly onToggleDarkMode: () => void;
   readonly onExportSVG: () => void;
+  readonly onExportPNG: () => void;
+  readonly onExportPDF?: (() => void) | undefined;
 }
 
 export function BracketHeader({
@@ -24,6 +26,8 @@ export function BracketHeader({
   onToggleNavigationMode,
   onToggleDarkMode,
   onExportSVG,
+  onExportPNG,
+  onExportPDF,
 }: BracketHeaderProps) {
   const { colors, header, typography } = useBracketAppearance();
 
@@ -100,6 +104,8 @@ export function BracketHeader({
           onToggleNavigationMode={onToggleNavigationMode}
           onToggleDarkMode={onToggleDarkMode}
           onExportSVG={onExportSVG}
+          onExportPNG={onExportPNG}
+          onExportPDF={onExportPDF}
         />
       ) : null}
     </div>

--- a/src/react-tournament-tree/src/components/BracketToolbar.tsx
+++ b/src/react-tournament-tree/src/components/BracketToolbar.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import { DownloadIcon, SunMoonIcon, ToolbarNavigationIcon } from './icons';
+import {
+  DownloadIcon,
+  PdfExportIcon,
+  PngExportIcon,
+  SunMoonIcon,
+  ToolbarNavigationIcon,
+} from './icons';
 
 interface BracketToolbarProps {
   readonly isDarkMode: boolean;
@@ -8,6 +14,8 @@ interface BracketToolbarProps {
   readonly onToggleDarkMode: () => void;
   readonly onToggleNavigationMode: () => void;
   readonly onExportSVG: () => void;
+  readonly onExportPNG: () => void;
+  readonly onExportPDF?: (() => void) | undefined;
 }
 
 export const BracketToolbar = React.memo<BracketToolbarProps>(function BracketToolbar({
@@ -16,6 +24,8 @@ export const BracketToolbar = React.memo<BracketToolbarProps>(function BracketTo
   onToggleDarkMode,
   onToggleNavigationMode,
   onExportSVG,
+  onExportPNG,
+  onExportPDF,
 }) {
   const buttonBaseStyle: React.CSSProperties = {
     display: 'flex',
@@ -50,6 +60,26 @@ export const BracketToolbar = React.memo<BracketToolbarProps>(function BracketTo
       >
         <DownloadIcon />
       </button>
+
+      <button
+        type="button"
+        onClick={onExportPNG}
+        style={buttonBaseStyle}
+        aria-label="Export as PNG"
+      >
+        <PngExportIcon />
+      </button>
+
+      {onExportPDF != null ? (
+        <button
+          type="button"
+          onClick={onExportPDF}
+          style={buttonBaseStyle}
+          aria-label="Export as PDF"
+        >
+          <PdfExportIcon />
+        </button>
+      ) : null}
 
       <button
         type="button"

--- a/src/react-tournament-tree/src/components/TournamentBracket.tsx
+++ b/src/react-tournament-tree/src/components/TournamentBracket.tsx
@@ -5,6 +5,8 @@ import React, { useMemo, useRef, useState } from 'react';
 
 import { BracketAppearanceProvider } from '../contexts/BracketAppearanceContext';
 import { BracketLocalizationProvider } from '../contexts/BracketLocalizationContext';
+import { useBracketPdfExport } from '../hooks/useBracketPdfExport';
+import { useBracketPngExport } from '../hooks/useBracketPngExport';
 import { useBracketSvgExport } from '../hooks/useBracketSvgExport';
 import {
   BracketVertexOptionsProvider,
@@ -38,6 +40,7 @@ export const TournamentBracket = React.memo<TournamentBracketProps>(function Tou
   toolbar,
   showToolbar,
   showViewportControls,
+  showPdfExport,
   defaultNavigationMode = true,
   theme,
   isDarkMode: controlledDarkMode,
@@ -60,6 +63,7 @@ export const TournamentBracket = React.memo<TournamentBracketProps>(function Tou
   const resolvedShowToolbar = showToolbar ?? toolbar?.showToolbar ?? true;
   const resolvedShowViewportControls =
     showViewportControls ?? toolbar?.showViewportControls ?? false;
+  const resolvedShowPdfExport = showPdfExport ?? toolbar?.showPdfExport ?? false;
   const resolvedPanEnabled = panEnabled ?? interaction?.panEnabled;
   const resolvedZoomEnabled = zoomEnabled ?? interaction?.zoomEnabled;
   const resolvedPinchZoomEnabled = pinchZoomEnabled ?? interaction?.pinchZoomEnabled;
@@ -114,7 +118,8 @@ export const TournamentBracket = React.memo<TournamentBracketProps>(function Tou
       onMatchUpdate,
       vertexComponent,
     });
-  const handleExportSVG = useBracketSvgExport({
+
+  const sharedExportParams = {
     wrapperRef,
     nodeRenderMode,
     vertexComponent,
@@ -127,7 +132,11 @@ export const TournamentBracket = React.memo<TournamentBracketProps>(function Tou
     resolvedLocalization,
     vertexOptions,
     onExportError,
-  });
+  };
+
+  const handleExportSVG = useBracketSvgExport(sharedExportParams);
+  const handleExportPNG = useBracketPngExport(sharedExportParams);
+  const handleExportPDF = useBracketPdfExport(sharedExportParams);
 
   return (
     <BracketAppearanceProvider resolvedAppearance={resolvedAppearance}>
@@ -152,6 +161,8 @@ export const TournamentBracket = React.memo<TournamentBracketProps>(function Tou
           onPagePlayersDown={navigation.handlePagePlayersDown}
           onToggleDarkMode={toggleDarkMode}
           onExportSVG={handleExportSVG}
+          onExportPNG={handleExportPNG}
+          onExportPDF={resolvedShowPdfExport ? handleExportPDF : undefined}
         >
           <BracketVertexOptionsProvider value={vertexOptions}>
             <BracketGraphCanvas

--- a/src/react-tournament-tree/src/components/__tests__/BracketFrame.test.tsx
+++ b/src/react-tournament-tree/src/components/__tests__/BracketFrame.test.tsx
@@ -26,6 +26,7 @@ const baseProps = {
   onPagePlayersDown: vi.fn(),
   onToggleDarkMode: vi.fn(),
   onExportSVG: vi.fn(),
+  onExportPNG: vi.fn(),
 };
 
 describe('BracketFrame', () => {

--- a/src/react-tournament-tree/src/components/__tests__/BracketHeader.test.tsx
+++ b/src/react-tournament-tree/src/components/__tests__/BracketHeader.test.tsx
@@ -14,6 +14,7 @@ const baseProps = {
   onToggleNavigationMode: vi.fn(),
   onToggleDarkMode: vi.fn(),
   onExportSVG: vi.fn(),
+  onExportPNG: vi.fn(),
 };
 
 describe('BracketHeader', () => {

--- a/src/react-tournament-tree/src/components/__tests__/BracketToolbar.test.tsx
+++ b/src/react-tournament-tree/src/components/__tests__/BracketToolbar.test.tsx
@@ -9,13 +9,25 @@ const baseProps = {
   onToggleNavigationMode: vi.fn(),
   onToggleDarkMode: vi.fn(),
   onExportSVG: vi.fn(),
+  onExportPNG: vi.fn(),
 };
 
 describe('BracketToolbar', () => {
-  it('renders three buttons', () => {
+  it('renders four buttons by default (SVG, PNG, Nav, DarkMode)', () => {
     render(<BracketToolbar {...baseProps} />);
-    expect(screen.getAllByRole('button')).toHaveLength(3);
+    expect(screen.getAllByRole('button')).toHaveLength(4);
     expect(screen.getByTestId('bracket-toolbar')).toHaveAttribute('data-print-hidden');
+  });
+
+  it('renders five buttons when onExportPDF is provided', () => {
+    render(<BracketToolbar {...baseProps} onExportPDF={vi.fn()} />);
+    expect(screen.getAllByRole('button')).toHaveLength(5);
+    expect(screen.getByRole('button', { name: 'Export as PDF' })).toBeInTheDocument();
+  });
+
+  it('does not render a PDF button when onExportPDF is not provided', () => {
+    render(<BracketToolbar {...baseProps} />);
+    expect(screen.queryByRole('button', { name: 'Export as PDF' })).not.toBeInTheDocument();
   });
 
   it('dark-mode button shows "Switch to Dark Mode" label in light mode', () => {
@@ -54,10 +66,24 @@ describe('BracketToolbar', () => {
     expect(onToggle).toHaveBeenCalledOnce();
   });
 
-  it('calls onExportSVG when export button is clicked', () => {
+  it('calls onExportSVG when SVG export button is clicked', () => {
     const onExportSVG = vi.fn();
     render(<BracketToolbar {...baseProps} onExportSVG={onExportSVG} />);
     fireEvent.click(screen.getByRole('button', { name: 'Export as SVG' }));
     expect(onExportSVG).toHaveBeenCalledOnce();
+  });
+
+  it('calls onExportPNG when PNG export button is clicked', () => {
+    const onExportPNG = vi.fn();
+    render(<BracketToolbar {...baseProps} onExportPNG={onExportPNG} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Export as PNG' }));
+    expect(onExportPNG).toHaveBeenCalledOnce();
+  });
+
+  it('calls onExportPDF when PDF export button is clicked', () => {
+    const onExportPDF = vi.fn();
+    render(<BracketToolbar {...baseProps} onExportPDF={onExportPDF} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Export as PDF' }));
+    expect(onExportPDF).toHaveBeenCalledOnce();
   });
 });

--- a/src/react-tournament-tree/src/components/icons/index.tsx
+++ b/src/react-tournament-tree/src/components/icons/index.tsx
@@ -177,3 +177,48 @@ export function ToolbarNavigationIcon({ isActive }: { readonly isActive: boolean
     </svg>
   );
 }
+
+export function PngExportIcon() {
+  return (
+    <svg
+      width={ICON_SIZE}
+      height={ICON_SIZE}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      data-testid="icon-svg"
+    >
+      {/* Image frame */}
+      <rect x="3" y="5" width="18" height="14" rx="2" stroke="currentColor" strokeWidth="1.8" />
+      {/* Mountain silhouette */}
+      <path
+        d="M3 15.5 8 11l4.5 4 3-3L21 16"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Sun circle */}
+      <circle cx="8" cy="10" r="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function PdfExportIcon() {
+  return (
+    <svg
+      width={ICON_SIZE}
+      height={ICON_SIZE}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      data-testid="icon-svg"
+    >
+      {/* Document outline with folded corner */}
+      <path d="M6 2h9l3 3v17H6V2z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+      <path d="M15 2v3h3" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+      {/* PDF lines */}
+      <path d="M9 12h6M9 15h4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/react-tournament-tree/src/hooks/__tests__/useBracketPngExport.test.tsx
+++ b/src/react-tournament-tree/src/hooks/__tests__/useBracketPngExport.test.tsx
@@ -1,0 +1,106 @@
+import { SquashNodeRenderMode } from '@graph-render/types/tournament';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BracketAppearanceProvider } from '../../contexts/BracketAppearanceContext';
+import { buildBracketSvgString } from '../../utils/buildBracketSvg';
+import { downloadPngFromSvgString } from '../../utils/exportPng';
+import { useBracketPngExport } from '../useBracketPngExport';
+
+vi.mock('../../utils/buildBracketSvg', () => ({
+  buildBracketSvgString: vi.fn(() => '<svg>test</svg>'),
+}));
+
+vi.mock('../../utils/exportPng', () => ({
+  downloadPngFromSvgString: vi.fn(async () => Promise.resolve()),
+}));
+
+const EMPTY_GRAPH = { nodes: {}, adj: {}, edges: {} };
+const FakeVertex = () => null;
+
+function makeWrapperRef(el: HTMLDivElement | null = null) {
+  return { current: el } as React.RefObject<HTMLDivElement | null>;
+}
+
+function makeDefaultParams(overrides = {}) {
+  return {
+    wrapperRef: makeWrapperRef(),
+    nodeRenderMode: SquashNodeRenderMode.Html,
+    vertexComponent: undefined,
+    isDarkMode: false,
+    enrichedGraph: EMPTY_GRAPH,
+    exportVertexComponent: FakeVertex,
+    mergedConfig: { width: 1600, height: 1200 } as never,
+    appearance: undefined,
+    compact: true,
+    vertexOptions: {
+      nodeRenderMode: SquashNodeRenderMode.Html,
+      compact: true,
+      onInvalidNode: undefined,
+    },
+    onExportError: undefined,
+    ...overrides,
+  };
+}
+
+describe('useBracketPngExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a stable callback reference', () => {
+    const params = makeDefaultParams();
+    const { result, rerender } = renderHook(() => useBracketPngExport(params));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('calls buildBracketSvgString and downloadPngFromSvgString when invoked', () => {
+    const params = makeDefaultParams();
+    const { result } = renderHook(() => useBracketPngExport(params), {
+      wrapper: ({ children }) => (
+        <BracketAppearanceProvider isDarkMode={false} compact>
+          {children}
+        </BracketAppearanceProvider>
+      ),
+    });
+
+    result.current();
+
+    expect(buildBracketSvgString).toHaveBeenCalledTimes(1);
+    expect(downloadPngFromSvgString).toHaveBeenCalledWith('<svg>test</svg>');
+  });
+
+  it('calls onExportError and rethrows when buildBracketSvgString throws', () => {
+    const onExportError = vi.fn();
+    const boom = new Error('svg build failed');
+    (buildBracketSvgString as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw boom;
+    });
+
+    const params = makeDefaultParams({ onExportError });
+    const { result } = renderHook(() => useBracketPngExport(params));
+
+    expect(() => result.current()).toThrow('svg build failed');
+    expect(onExportError).toHaveBeenCalledWith(boom);
+  });
+
+  it('calls onExportError when downloadPngFromSvgString rejects', async () => {
+    const onExportError = vi.fn();
+    const boom = new Error('png conversion failed');
+    (downloadPngFromSvgString as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      Promise.reject(boom)
+    );
+
+    const params = makeDefaultParams({ onExportError });
+    const { result } = renderHook(() => useBracketPngExport(params));
+
+    result.current();
+
+    // Wait for the promise rejection to be handled
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onExportError).toHaveBeenCalledWith(boom);
+  });
+});

--- a/src/react-tournament-tree/src/hooks/useBracketPdfExport.tsx
+++ b/src/react-tournament-tree/src/hooks/useBracketPdfExport.tsx
@@ -1,0 +1,81 @@
+import type { GraphConfig } from '@graph-render/types';
+import type { VertexComponent } from '@graph-render/types/react';
+import { useCallback } from 'react';
+
+import type { BracketVertexOptions } from '../hooks/useBracketVertexComponents';
+import type { ResolvedTournamentLocalization } from '../models/localization';
+import type { TournamentBracketProps } from '../models/tournamentBracket';
+import { buildBracketSvgString } from '../utils/buildBracketSvg';
+import { downloadPdfFromSvgString } from '../utils/exportPdf';
+import { resolveTournamentLocalization } from '../utils/localization';
+
+interface UseBracketPdfExportParams {
+  readonly wrapperRef: React.RefObject<HTMLDivElement | null>;
+  readonly nodeRenderMode: NonNullable<TournamentBracketProps['nodeRenderMode']>;
+  readonly vertexComponent?: TournamentBracketProps['vertexComponent'];
+  readonly isDarkMode: boolean;
+  readonly enrichedGraph: TournamentBracketProps['graph'];
+  readonly exportVertexComponent: VertexComponent;
+  readonly mergedConfig: GraphConfig;
+  readonly appearance?: TournamentBracketProps['appearance'];
+  readonly compact: boolean;
+  readonly resolvedLocalization?: ResolvedTournamentLocalization | undefined;
+  readonly vertexOptions: BracketVertexOptions;
+  readonly onExportError?: TournamentBracketProps['onExportError'];
+}
+
+export function useBracketPdfExport({
+  wrapperRef,
+  nodeRenderMode,
+  vertexComponent,
+  isDarkMode,
+  enrichedGraph,
+  exportVertexComponent,
+  mergedConfig,
+  appearance,
+  compact,
+  resolvedLocalization = resolveTournamentLocalization(),
+  vertexOptions,
+  onExportError,
+}: UseBracketPdfExportParams) {
+  return useCallback(() => {
+    let svgString: string;
+    try {
+      svgString = buildBracketSvgString({
+        wrapperRef,
+        nodeRenderMode,
+        vertexComponent,
+        isDarkMode,
+        enrichedGraph,
+        exportVertexComponent,
+        mergedConfig,
+        appearance,
+        compact,
+        resolvedLocalization,
+        vertexOptions,
+      });
+    } catch (error) {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      onExportError?.(normalizedError);
+      throw normalizedError;
+    }
+
+    downloadPdfFromSvgString(svgString).catch((error: unknown) => {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      onExportError?.(normalizedError);
+    });
+  }, [
+    enrichedGraph,
+    exportVertexComponent,
+    appearance,
+    compact,
+    isDarkMode,
+    mergedConfig,
+    nodeRenderMode,
+    onExportError,
+    resolvedLocalization,
+    vertexComponent,
+    vertexOptions,
+    wrapperRef,
+  ]);
+}

--- a/src/react-tournament-tree/src/hooks/useBracketPngExport.tsx
+++ b/src/react-tournament-tree/src/hooks/useBracketPngExport.tsx
@@ -1,0 +1,81 @@
+import type { GraphConfig } from '@graph-render/types';
+import type { VertexComponent } from '@graph-render/types/react';
+import { useCallback } from 'react';
+
+import type { BracketVertexOptions } from '../hooks/useBracketVertexComponents';
+import type { ResolvedTournamentLocalization } from '../models/localization';
+import type { TournamentBracketProps } from '../models/tournamentBracket';
+import { buildBracketSvgString } from '../utils/buildBracketSvg';
+import { downloadPngFromSvgString } from '../utils/exportPng';
+import { resolveTournamentLocalization } from '../utils/localization';
+
+interface UseBracketPngExportParams {
+  readonly wrapperRef: React.RefObject<HTMLDivElement | null>;
+  readonly nodeRenderMode: NonNullable<TournamentBracketProps['nodeRenderMode']>;
+  readonly vertexComponent?: TournamentBracketProps['vertexComponent'];
+  readonly isDarkMode: boolean;
+  readonly enrichedGraph: TournamentBracketProps['graph'];
+  readonly exportVertexComponent: VertexComponent;
+  readonly mergedConfig: GraphConfig;
+  readonly appearance?: TournamentBracketProps['appearance'];
+  readonly compact: boolean;
+  readonly resolvedLocalization?: ResolvedTournamentLocalization | undefined;
+  readonly vertexOptions: BracketVertexOptions;
+  readonly onExportError?: TournamentBracketProps['onExportError'];
+}
+
+export function useBracketPngExport({
+  wrapperRef,
+  nodeRenderMode,
+  vertexComponent,
+  isDarkMode,
+  enrichedGraph,
+  exportVertexComponent,
+  mergedConfig,
+  appearance,
+  compact,
+  resolvedLocalization = resolveTournamentLocalization(),
+  vertexOptions,
+  onExportError,
+}: UseBracketPngExportParams) {
+  return useCallback(() => {
+    let svgString: string;
+    try {
+      svgString = buildBracketSvgString({
+        wrapperRef,
+        nodeRenderMode,
+        vertexComponent,
+        isDarkMode,
+        enrichedGraph,
+        exportVertexComponent,
+        mergedConfig,
+        appearance,
+        compact,
+        resolvedLocalization,
+        vertexOptions,
+      });
+    } catch (error) {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      onExportError?.(normalizedError);
+      throw normalizedError;
+    }
+
+    downloadPngFromSvgString(svgString).catch((error: unknown) => {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      onExportError?.(normalizedError);
+    });
+  }, [
+    enrichedGraph,
+    exportVertexComponent,
+    appearance,
+    compact,
+    isDarkMode,
+    mergedConfig,
+    nodeRenderMode,
+    onExportError,
+    resolvedLocalization,
+    vertexComponent,
+    vertexOptions,
+    wrapperRef,
+  ]);
+}

--- a/src/react-tournament-tree/src/models/tournamentBracket.ts
+++ b/src/react-tournament-tree/src/models/tournamentBracket.ts
@@ -25,6 +25,8 @@ export interface TournamentBracketThemeOptions {
 export interface TournamentBracketToolbarOptions {
   readonly showToolbar?: boolean | undefined;
   readonly showViewportControls?: boolean | undefined;
+  /** When true, shows a PDF export button in the toolbar. Requires jspdf to be installed. */
+  readonly showPdfExport?: boolean | undefined;
 }
 
 export interface TournamentMatchUpdatePayload {
@@ -46,6 +48,8 @@ export interface TournamentBracketProps {
   readonly toolbar?: TournamentBracketToolbarOptions | undefined;
   readonly showToolbar?: boolean | undefined;
   readonly showViewportControls?: boolean | undefined;
+  /** When true, shows a PDF export button in the toolbar. Requires jspdf to be installed. */
+  readonly showPdfExport?: boolean | undefined;
   readonly defaultNavigationMode?: boolean | undefined;
   /** Prefer grouped theme options; flat props remain supported for compatibility. */
   readonly theme?: TournamentBracketThemeOptions | undefined;

--- a/src/react-tournament-tree/src/types/jspdf.d.ts
+++ b/src/react-tournament-tree/src/types/jspdf.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal type declarations for the optional jspdf peer dependency.
+ *
+ * jspdf is not installed by default. If you want PDF export, install it:
+ *   npm install jspdf
+ *
+ * Browser limitations: custom fonts and cross-origin images may not render
+ * correctly in the exported PDF, for the same reasons as the PNG export.
+ */
+declare module 'jspdf' {
+  interface JsPDFOptions {
+    orientation?: 'portrait' | 'landscape';
+    unit?: string;
+    format?: [number, number] | string;
+  }
+
+  export class jsPDF {
+    constructor(options?: JsPDFOptions);
+    addImage(
+      data: string,
+      format: string,
+      x: number,
+      y: number,
+      width: number,
+      height: number
+    ): this;
+    save(filename?: string): void;
+  }
+
+  export default jsPDF;
+}

--- a/src/react-tournament-tree/src/utils/__tests__/exportPdf.test.ts
+++ b/src/react-tournament-tree/src/utils/__tests__/exportPdf.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadPdfFromSvgString, PdfExportError } from '../exportPdf';
+
+const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"></svg>';
+
+// vi.mock is hoisted — define the spy at module scope so tests can inspect it.
+const mockSave = vi.fn();
+// Must use function keyword so it can be called with `new`
+const MockJsPDFConstructor = vi.fn(function MockJsPDF() {
+  return { addImage: vi.fn(), save: mockSave };
+});
+
+vi.mock('jspdf', () => ({
+  jsPDF: MockJsPDFConstructor,
+}));
+
+let lastMockImage: MockImageInstance | null = null;
+
+class MockImageInstance {
+  src = '';
+  naturalWidth = 800;
+  naturalHeight = 600;
+  private readonly listeners = new Map<string, (e: Event) => void>();
+
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- needed to capture `this` for the closure below
+    lastMockImage = this;
+  }
+
+  addEventListener(event: string, cb: (e: Event) => void) {
+    this.listeners.set(event, cb);
+  }
+
+  simulateLoad() {
+    this.listeners.get('load')?.(new Event('load'));
+  }
+}
+
+beforeEach(() => {
+  lastMockImage = null;
+  mockSave.mockClear();
+  MockJsPDFConstructor.mockClear();
+  URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+  URL.revokeObjectURL = vi.fn();
+  vi.stubGlobal('Image', MockImageInstance);
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage: vi.fn(),
+  } as unknown as CanvasRenderingContext2D);
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+    (cb: (b: Blob | null) => void) => {
+      cb(new Blob(['png'], { type: 'image/png' }));
+    }
+  );
+  const MockFileReader = vi.fn().mockImplementation(function MockFR(this: FileReader) {
+    Object.defineProperty(this, 'result', {
+      get: () => 'data:image/png;base64,abc',
+    });
+    (this as unknown as Record<string, unknown>)['addEventListener'] = (
+      event: string,
+      cb: () => void
+    ) => {
+      if (event === 'load') queueMicrotask(cb);
+    };
+    (this as unknown as Record<string, unknown>)['readAsDataURL'] = vi.fn();
+  });
+  vi.stubGlobal('FileReader', MockFileReader);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('downloadPdfFromSvgString', () => {
+  it('calls jsPDF save() and addImage() after PNG conversion', async () => {
+    const downloadPromise = downloadPdfFromSvgString(MINIMAL_SVG, 'bracket.pdf');
+
+    // The dynamic import of jspdf + svgStringToPngBlob takes a few microtask ticks
+    // before new Image() is called. Poll until it's set.
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+      if (lastMockImage !== null) break;
+    }
+    expect(lastMockImage).not.toBeNull();
+    lastMockImage!.simulateLoad();
+    await downloadPromise;
+
+    expect(MockJsPDFConstructor).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledWith('bracket.pdf');
+  });
+
+  it('PdfExportError is an instance of Error with correct name', () => {
+    const err = new PdfExportError('test message');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('PdfExportError');
+    expect(err.message).toBe('test message');
+  });
+});

--- a/src/react-tournament-tree/src/utils/__tests__/exportPng.test.ts
+++ b/src/react-tournament-tree/src/utils/__tests__/exportPng.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadPngFromSvgString, PngExportError, svgStringToPngBlob } from '../exportPng';
+
+const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"></svg>';
+
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+
+// Keep a reference to the most recently created mock image so tests can trigger events.
+let lastMockImage: MockImageInstance | null = null;
+
+class MockImageInstance {
+  src = '';
+  naturalWidth = 100;
+  naturalHeight = 50;
+  width = 100;
+  height = 50;
+  private readonly listeners = new Map<string, (e: Event) => void>();
+
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- needed to capture `this` for the closure below
+    lastMockImage = this;
+  }
+
+  addEventListener(event: string, cb: (e: Event) => void) {
+    this.listeners.set(event, cb);
+  }
+
+  simulateLoad() {
+    this.listeners.get('load')?.(new Event('load'));
+  }
+
+  simulateError() {
+    this.listeners.get('error')?.(new Event('error'));
+  }
+}
+
+beforeEach(() => {
+  URL.createObjectURL = mockCreateObjectURL;
+  URL.revokeObjectURL = mockRevokeObjectURL;
+  mockCreateObjectURL.mockClear();
+  mockRevokeObjectURL.mockClear();
+  lastMockImage = null;
+  vi.stubGlobal('Image', MockImageInstance);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('svgStringToPngBlob', () => {
+  it('rejects with PngExportError for an empty SVG string', async () => {
+    await expect(svgStringToPngBlob('   ')).rejects.toThrow(PngExportError);
+  });
+
+  it('resolves with a Blob when the image loads successfully', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+      (cb: (b: Blob | null) => void) => {
+        cb(new Blob(['png-data'], { type: 'image/png' }));
+      }
+    );
+
+    const blobPromise = svgStringToPngBlob(MINIMAL_SVG);
+    lastMockImage!.simulateLoad();
+
+    const blob = await blobPromise;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/png');
+  });
+
+  it('rejects with PngExportError when the image fails to load', async () => {
+    const blobPromise = svgStringToPngBlob(MINIMAL_SVG);
+    lastMockImage!.simulateError();
+
+    await expect(blobPromise).rejects.toThrow(PngExportError);
+  });
+
+  it('rejects with PngExportError when canvas context is unavailable', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+
+    const blobPromise = svgStringToPngBlob(MINIMAL_SVG);
+    lastMockImage!.simulateLoad();
+
+    await expect(blobPromise).rejects.toThrow(PngExportError);
+  });
+
+  it('rejects with PngExportError when toBlob returns null', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+      (cb: (b: Blob | null) => void) => {
+        cb(null);
+      }
+    );
+
+    const blobPromise = svgStringToPngBlob(MINIMAL_SVG);
+    lastMockImage!.simulateLoad();
+
+    await expect(blobPromise).rejects.toThrow(PngExportError);
+  });
+});
+
+describe('downloadPngFromSvgString', () => {
+  it('triggers a download anchor click after PNG conversion', async () => {
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+      (cb: (b: Blob | null) => void) => {
+        cb(new Blob(['png'], { type: 'image/png' }));
+      }
+    );
+
+    const downloadPromise = downloadPngFromSvgString(MINIMAL_SVG, 'test.png');
+    lastMockImage!.simulateLoad();
+
+    await downloadPromise;
+
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
+  });
+});

--- a/src/react-tournament-tree/src/utils/__tests__/exportSvg.test.ts
+++ b/src/react-tournament-tree/src/utils/__tests__/exportSvg.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { downloadSvgFromElement, SvgExportError } from '../exportSvg';
+import { downloadSvgFromElement, getSvgStringFromElement, SvgExportError } from '../exportSvg';
 
 // jsdom does not implement URL.createObjectURL, so we must mock it.
 const mockCreateObjectURL = vi.fn((_blob: Blob) => 'blob:mock-url');
@@ -27,6 +27,34 @@ function makeSvgContainer(): HTMLDivElement {
   document.body.append(container);
   return container;
 }
+
+describe('getSvgStringFromElement', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('throws SvgExportError when rootElement is null', () => {
+    expect(() => getSvgStringFromElement(null)).toThrow(SvgExportError);
+  });
+
+  it('throws SvgExportError when there is no <svg> inside rootElement', () => {
+    const div = document.createElement('div');
+    expect(() => getSvgStringFromElement(div)).toThrow(SvgExportError);
+  });
+
+  it('returns an SVG string with xmlns attributes', () => {
+    const container = makeSvgContainer();
+    const result = getSvgStringFromElement(container);
+    expect(result).toContain('xmlns="http://www.w3.org/2000/svg"');
+    expect(result).toContain('xmlns:xlink="http://www.w3.org/1999/xlink"');
+  });
+
+  it('returns a non-empty string containing <svg', () => {
+    const container = makeSvgContainer();
+    const result = getSvgStringFromElement(container);
+    expect(result).toMatch(/<svg/);
+  });
+});
 
 describe('downloadSvgFromElement', () => {
   afterEach(() => {

--- a/src/react-tournament-tree/src/utils/buildBracketSvg.tsx
+++ b/src/react-tournament-tree/src/utils/buildBracketSvg.tsx
@@ -1,0 +1,106 @@
+import { renderGraphToSvg } from '@graph-render/core';
+import { Graph } from '@graph-render/react';
+import type { GraphConfig } from '@graph-render/types';
+import type { VertexComponent } from '@graph-render/types/react';
+import { SquashNodeRenderMode } from '@graph-render/types/tournament';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+
+import { BracketAppearanceProvider } from '../contexts/BracketAppearanceContext';
+import { BracketLocalizationProvider } from '../contexts/BracketLocalizationContext';
+import type { BracketVertexOptions } from '../hooks/useBracketVertexComponents';
+import { BracketVertexOptionsProvider } from '../hooks/useBracketVertexComponents';
+import type { ResolvedTournamentLocalization } from '../models/localization';
+import type { TournamentBracketProps } from '../models/tournamentBracket';
+import { routeBracketEdges } from './bracketRouting';
+import { getSvgStringFromElement } from './exportSvg';
+
+export interface BuildBracketSvgParams {
+  readonly wrapperRef: React.RefObject<HTMLDivElement | null>;
+  readonly nodeRenderMode: NonNullable<TournamentBracketProps['nodeRenderMode']>;
+  readonly vertexComponent?: TournamentBracketProps['vertexComponent'];
+  readonly isDarkMode: boolean;
+  readonly enrichedGraph: TournamentBracketProps['graph'];
+  readonly exportVertexComponent: VertexComponent;
+  readonly mergedConfig: GraphConfig;
+  readonly appearance?: TournamentBracketProps['appearance'];
+  readonly compact: boolean;
+  readonly resolvedLocalization: ResolvedTournamentLocalization;
+  readonly vertexOptions: BracketVertexOptions;
+}
+
+/**
+ * Builds and returns the bracket SVG as a string without triggering a download.
+ * Handles all three render modes (Svg, Export, Html).
+ */
+export function buildBracketSvgString({
+  wrapperRef,
+  nodeRenderMode,
+  vertexComponent,
+  isDarkMode,
+  enrichedGraph,
+  exportVertexComponent,
+  mergedConfig,
+  appearance,
+  compact,
+  resolvedLocalization,
+  vertexOptions,
+}: BuildBracketSvgParams): string {
+  if (
+    nodeRenderMode === SquashNodeRenderMode.Svg &&
+    !vertexComponent &&
+    enrichedGraph.nodes != null
+  ) {
+    const { svg } = renderGraphToSvg(enrichedGraph, {
+      config: {
+        width: mergedConfig.width,
+        height: mergedConfig.height,
+      },
+      title: 'Tournament Bracket',
+    });
+    return svg;
+  }
+
+  if (nodeRenderMode !== SquashNodeRenderMode.Html || vertexComponent) {
+    return getSvgStringFromElement(wrapperRef.current);
+  }
+
+  const host = document.createElement('div');
+  host.style.position = 'absolute';
+  host.style.width = '0';
+  host.style.height = '0';
+  host.style.overflow = 'hidden';
+  host.style.opacity = '0';
+  host.style.pointerEvents = 'none';
+  document.body.append(host);
+
+  const exportRoot = createRoot(host);
+
+  try {
+    flushSync(() => {
+      exportRoot.render(
+        <BracketAppearanceProvider
+          appearance={appearance}
+          isDarkMode={isDarkMode}
+          compact={compact}
+        >
+          <BracketLocalizationProvider resolvedLocalization={resolvedLocalization}>
+            <BracketVertexOptionsProvider value={vertexOptions}>
+              <Graph
+                graph={enrichedGraph}
+                vertexComponent={exportVertexComponent}
+                config={mergedConfig}
+                routeEdgesOverride={routeBracketEdges}
+              />
+            </BracketVertexOptionsProvider>
+          </BracketLocalizationProvider>
+        </BracketAppearanceProvider>
+      );
+    });
+
+    return getSvgStringFromElement(host);
+  } finally {
+    exportRoot.unmount();
+    host.remove();
+  }
+}

--- a/src/react-tournament-tree/src/utils/exportPdf.ts
+++ b/src/react-tournament-tree/src/utils/exportPdf.ts
@@ -1,0 +1,100 @@
+import type { jsPDF as JsPDFType } from 'jspdf';
+
+import { svgStringToPngBlob } from './exportPng';
+
+export class PdfExportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PdfExportError';
+  }
+}
+
+function parseSvgDimensions(svgString: string): { width: number; height: number } {
+  const widthMatch = /\bwidth="([\d.]+)"/.exec(svgString);
+  const heightMatch = /\bheight="([\d.]+)"/.exec(svgString);
+
+  if (widthMatch && heightMatch) {
+    const w = parseFloat(widthMatch[1] ?? '');
+    const h = parseFloat(heightMatch[1] ?? '');
+    if (w > 0 && h > 0) return { width: w, height: h };
+  }
+
+  const viewBoxMatch = /\bviewBox="([^"]+)"/.exec(svgString);
+  if (viewBoxMatch) {
+    const parts = (viewBoxMatch[1] ?? '').trim().split(/[\s,]+/);
+    if (parts.length === 4) {
+      const w = parseFloat(parts[2]!);
+      const h = parseFloat(parts[3]!);
+      if (w > 0 && h > 0) return { width: w, height: h };
+    }
+  }
+
+  return { width: 800, height: 600 };
+}
+
+type JsPDFConstructor = new (options?: {
+  orientation?: 'portrait' | 'landscape';
+  unit?: string;
+  format?: [number, number] | string;
+}) => JsPDFType;
+
+/**
+ * Exports the bracket as a PDF file.
+ *
+ * Requires the optional `jspdf` package to be installed:
+ *   npm install jspdf
+ *
+ * Browser limitations: same as PNG export — custom fonts and cross-origin
+ * images may not appear correctly.
+ */
+export async function downloadPdfFromSvgString(
+  svgString: string,
+  filename?: string
+): Promise<void> {
+  let JsPDF: JsPDFConstructor;
+  try {
+    // eslint-disable-next-line import/no-unresolved -- jspdf is an optional peer dependency; install with: npm install jspdf
+    const jsPdfModule = await import('jspdf');
+    // jsPDF may be the default export or named export depending on the bundler.
+    const resolved: unknown =
+      (jsPdfModule as { jsPDF?: unknown }).jsPDF ??
+      (jsPdfModule as { default?: { jsPDF?: unknown } }).default?.jsPDF ??
+      (jsPdfModule as { default?: unknown }).default;
+    if (typeof resolved !== 'function') {
+      throw new PdfExportError(
+        'Could not resolve jsPDF constructor. Ensure jspdf is correctly installed.'
+      );
+    }
+    JsPDF = resolved as JsPDFConstructor;
+  } catch (err) {
+    if (err instanceof PdfExportError) throw err;
+    throw new PdfExportError('PDF export requires jsPDF. Install it with: npm install jspdf');
+  }
+
+  const pngBlob = await svgStringToPngBlob(svgString);
+  const pngDataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => resolve(reader.result as string));
+    reader.addEventListener('error', () =>
+      reject(new PdfExportError('Failed to read PNG data for PDF embedding.'))
+    );
+    reader.readAsDataURL(pngBlob);
+  });
+
+  const { width, height } = parseSvgDimensions(svgString);
+
+  // Use landscape orientation when the bracket is wider than it is tall.
+  const orientation = width >= height ? 'landscape' : 'portrait';
+  const ptPerPx = 0.75;
+  const pageWidth = width * ptPerPx;
+  const pageHeight = height * ptPerPx;
+
+  const doc = new JsPDF({
+    orientation,
+    unit: 'pt',
+    format: [pageWidth, pageHeight],
+  });
+
+  doc.addImage(pngDataUrl, 'PNG', 0, 0, pageWidth, pageHeight);
+  doc.save(filename ?? `tournament-bracket-${Date.now()}.pdf`);
+}

--- a/src/react-tournament-tree/src/utils/exportPng.ts
+++ b/src/react-tournament-tree/src/utils/exportPng.ts
@@ -1,0 +1,110 @@
+export class PngExportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PngExportError';
+  }
+}
+
+function parseSvgDimensions(svgString: string): { width: number; height: number } {
+  const widthMatch = /\bwidth="([\d.]+)"/.exec(svgString);
+  const heightMatch = /\bheight="([\d.]+)"/.exec(svgString);
+
+  if (widthMatch && heightMatch) {
+    const w = parseFloat(widthMatch[1] ?? '');
+    const h = parseFloat(heightMatch[1] ?? '');
+    if (w > 0 && h > 0) return { width: w, height: h };
+  }
+
+  const viewBoxMatch = /\bviewBox="([^"]+)"/.exec(svgString);
+  if (viewBoxMatch) {
+    const parts = (viewBoxMatch[1] ?? '').trim().split(/[\s,]+/);
+    if (parts.length === 4) {
+      const w = parseFloat(parts[2]!);
+      const h = parseFloat(parts[3]!);
+      if (w > 0 && h > 0) return { width: w, height: h };
+    }
+  }
+
+  return { width: 0, height: 0 };
+}
+
+/**
+ * Converts an SVG string to a PNG Blob using the Canvas API.
+ *
+ * Browser limitations:
+ * - Custom fonts loaded via @font-face may not render unless they are already
+ *   loaded in the document at export time.
+ * - Cross-origin images embedded in the SVG will be blocked by CORS and will
+ *   not appear in the exported PNG.
+ * - On some browsers, tainted-canvas security restrictions may prevent export
+ *   when cross-origin images are present.
+ */
+export async function svgStringToPngBlob(svgString: string): Promise<Blob> {
+  if (!svgString.trim()) {
+    throw new PngExportError('Cannot export an empty SVG document.');
+  }
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+    const objectUrl = URL.createObjectURL(svgBlob);
+    const dimensions = parseSvgDimensions(svgString);
+
+    img.addEventListener('load', () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = dimensions.width || img.naturalWidth || img.width || 800;
+        canvas.height = dimensions.height || img.naturalHeight || img.height || 600;
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          URL.revokeObjectURL(objectUrl);
+          reject(new PngExportError('Cannot create canvas 2D context for PNG export.'));
+          return;
+        }
+
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+        canvas.toBlob((blob) => {
+          URL.revokeObjectURL(objectUrl);
+          if (blob) {
+            resolve(blob);
+          } else {
+            reject(new PngExportError('Failed to convert canvas to PNG blob.'));
+          }
+        }, 'image/png');
+      } catch (err) {
+        URL.revokeObjectURL(objectUrl);
+        reject(err instanceof Error ? err : new PngExportError(String(err)));
+      }
+    });
+
+    img.addEventListener('error', () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(
+        new PngExportError(
+          'Failed to load SVG for PNG export. ' +
+            'Custom fonts and cross-origin images may not render correctly in PNG exports.'
+        )
+      );
+    });
+
+    img.src = objectUrl;
+  });
+}
+
+export async function downloadPngFromSvgString(
+  svgString: string,
+  filename?: string
+): Promise<void> {
+  const blob = await svgStringToPngBlob(svgString);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = filename ?? `tournament-bracket-${Date.now()}.png`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/react-tournament-tree/src/utils/exportSvg.ts
+++ b/src/react-tournament-tree/src/utils/exportSvg.ts
@@ -22,12 +22,12 @@ export function downloadSvgString(svgString: string, filename?: string) {
   URL.revokeObjectURL(url);
 }
 
-export function downloadSvgFromElement(rootElement: Element | null) {
+export function getSvgStringFromElement(rootElement: Element | null): string {
   if (!rootElement) {
     throw new SvgExportError('Cannot export SVG because the export root element is missing.');
   }
 
-  const svgElement = rootElement?.querySelector('svg');
+  const svgElement = rootElement.querySelector('svg');
   if (!svgElement) {
     throw new SvgExportError('Cannot export SVG because no <svg> element was found.');
   }
@@ -36,6 +36,9 @@ export function downloadSvgFromElement(rootElement: Element | null) {
   clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
   clonedSvg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
 
-  const serializer = new XMLSerializer();
-  downloadSvgString(serializer.serializeToString(clonedSvg));
+  return new XMLSerializer().serializeToString(clonedSvg);
+}
+
+export function downloadSvgFromElement(rootElement: Element | null) {
+  downloadSvgString(getSvgStringFromElement(rootElement));
 }

--- a/src/react-tournament-tree/vitest.config.ts
+++ b/src/react-tournament-tree/vitest.config.ts
@@ -1,8 +1,16 @@
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // Provides a minimal jsPDF stub so dynamic import('jspdf') resolves in tests.
+      // jspdf is an optional peer dependency; real integration tests should install it.
+      jspdf: path.resolve(__dirname, 'src/__mocks__/jspdf.ts'),
+    },
+  },
   benchmark: {
     include: ['src/**/*.bench.ts'],
   },

--- a/src/types/CHANGELOG.md
+++ b/src/types/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## @graph-render/types 1.4.0 (2026-05-25)
 
-* feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
+- feat(tournament): localize schedule metadata (#28) ([40f49e1](https://github.com/graph-render/graph-render/commit/40f49e1)), closes [#28](https://github.com/graph-render/graph-render/issues/28)
 
 ## @graph-render/types 1.3.0 (2026-05-24)
 


### PR DESCRIPTION
- Add PNG export via Canvas API (SVG → Image → Canvas → Blob → download)
- Add optional PDF export via dynamic import of jspdf (install separately)
- Add PngExportIcon and PdfExportIcon to toolbar
- Add onExportPNG (required) and onExportPDF (optional) props throughout BracketToolbar → BracketHeader → BracketFrame → TournamentBracket
- Add showPdfExport prop to TournamentBracketToolbarOptions (default false)
- Add useBracketPngExport and useBracketPdfExport hooks
- Add buildBracketSvgString shared helper for all three render modes
- Add getSvgStringFromElement to exportSvg utilities
- Add minimal jspdf type declarations and test stub
- Update vitest config with jspdf alias for test isolation
- Full coverage: 522 tests passing, typecheck, lint, build all green