### PR TITLE
feat(bracket): add Swiss System tournament support (#18)

### DIFF
--- a/.storybook/stories/bracket/SwissBracket.stories.tsx
+++ b/.storybook/stories/bracket/SwissBracket.stories.tsx
@@ -1,0 +1,178 @@
+import type { SwissMatch } from '@graph-render/tournament-tree';
+import { MatchStatus, SwissBracket } from '@graph-render/tournament-tree';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const participants = [
+  { name: 'Magnus Carlsen', seed: 1, country: 'NOR' },
+  { name: 'Fabiano Caruana', seed: 2, country: 'USA' },
+  { name: 'Ding Liren', seed: 3, country: 'CHN' },
+  { name: 'Ian Nepomniachtchi', seed: 4, country: 'RUS' },
+  { name: 'Anish Giri', seed: 5, country: 'NED' },
+  { name: 'Levon Aronian', seed: 6, country: 'ARM' },
+];
+
+// Manual pairings for a 5-round Swiss event.
+const matches: readonly SwissMatch[] = [
+  // Round 1
+  {
+    id: 'r1-m1',
+    players: [{ name: 'Magnus Carlsen' }, { name: 'Levon Aronian' }],
+    round: 1,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r1-m2',
+    players: [{ name: 'Fabiano Caruana' }, { name: 'Anish Giri' }],
+    round: 1,
+    scores: [0, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r1-m3',
+    players: [{ name: 'Ding Liren' }, { name: 'Ian Nepomniachtchi' }],
+    round: 1,
+    scores: [0, 1],
+    status: MatchStatus.Completed,
+  },
+  // Round 2
+  {
+    id: 'r2-m1',
+    players: [{ name: 'Ian Nepomniachtchi' }, { name: 'Magnus Carlsen' }],
+    round: 2,
+    scores: [0, 1],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r2-m2',
+    players: [{ name: 'Anish Giri' }, { name: 'Ding Liren' }],
+    round: 2,
+    scores: [0, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r2-m3',
+    players: [{ name: 'Levon Aronian' }, { name: 'Fabiano Caruana' }],
+    round: 2,
+    scores: [0, 1],
+    status: MatchStatus.Completed,
+  },
+  // Round 3
+  {
+    id: 'r3-m1',
+    players: [{ name: 'Magnus Carlsen' }, { name: 'Fabiano Caruana' }],
+    round: 3,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r3-m2',
+    players: [{ name: 'Ian Nepomniachtchi' }, { name: 'Anish Giri' }],
+    round: 3,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r3-m3',
+    players: [{ name: 'Ding Liren' }, { name: 'Levon Aronian' }],
+    round: 3,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  // Round 4
+  {
+    id: 'r4-m1',
+    players: [{ name: 'Magnus Carlsen' }, { name: 'Ding Liren' }],
+    round: 4,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r4-m2',
+    players: [{ name: 'Ian Nepomniachtchi' }, { name: 'Fabiano Caruana' }],
+    round: 4,
+    scores: [0, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r4-m3',
+    players: [{ name: 'Anish Giri' }, { name: 'Levon Aronian' }],
+    round: 4,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  // Round 5
+  {
+    id: 'r5-m1',
+    players: [{ name: 'Magnus Carlsen' }, { name: 'Ian Nepomniachtchi' }],
+    round: 5,
+    status: MatchStatus.Upcoming,
+  },
+  {
+    id: 'r5-m2',
+    players: [{ name: 'Fabiano Caruana' }, { name: 'Ding Liren' }],
+    round: 5,
+    status: MatchStatus.Upcoming,
+  },
+  {
+    id: 'r5-m3',
+    players: [{ name: 'Anish Giri' }, { name: 'Levon Aronian' }],
+    round: 5,
+    status: MatchStatus.Upcoming,
+  },
+];
+
+const meta: Meta<typeof SwissBracket> = {
+  title: 'Tournament/Swiss',
+  component: SwissBracket,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  args: {
+    compact: false,
+    groupName: 'Open',
+    matches,
+    participants,
+    points: { draw: 0.5, loss: 0, win: 1 },
+    title: 'World Chess Championship — Swiss',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SwissBracket>;
+
+/** Full 5-round Swiss with standings, Buchholz, and Sonneborn-Berger tiebreakers. */
+export const FiveRounds: Story = {
+  name: 'Five-round Swiss — standings + schedule',
+};
+
+/** Chess uses 1/0.5/0. Esports might prefer 3/1/0. */
+export const CustomPoints: Story = {
+  name: 'Custom points (esports: 3/1/0)',
+  args: {
+    points: { win: 3, draw: 1, loss: 0 },
+    title: 'Esports Swiss — 3/1/0 Points',
+  },
+};
+
+export const NoMatchesYet: Story = {
+  name: 'No pairings yet',
+  args: {
+    matches: undefined,
+    title: 'Swiss — Pairings Pending',
+  },
+};
+
+export const DarkMode: Story = {
+  name: 'Dark mode',
+  args: {
+    isDarkMode: true,
+  },
+};
+
+export const Compact: Story = {
+  name: 'Compact layout',
+  args: {
+    compact: true,
+  },
+};

--- a/src/react-tournament-tree/src/components/SwissBracket.tsx
+++ b/src/react-tournament-tree/src/components/SwissBracket.tsx
@@ -1,0 +1,347 @@
+import type {
+  SwissMatch,
+  SwissPointsRule,
+  TournamentBracketAppearance,
+} from '@graph-render/types/tournament';
+import { MatchStatus } from '@graph-render/types/tournament';
+import React, { useMemo } from 'react';
+
+import {
+  BracketAppearanceProvider,
+  useBracketAppearance,
+} from '../contexts/BracketAppearanceContext';
+import {
+  BracketLocalizationProvider,
+  useBracketLocalization,
+} from '../contexts/BracketLocalizationContext';
+import type { TournamentLocalizationOptions } from '../models/localization';
+import { formatStatusLabel, getMatchScheduleText } from '../utils/localization';
+import type { TournamentParticipantInput } from '../utils/tournament';
+import { calculateSwissStandings, groupSwissMatchesByRound } from '../utils/tournament';
+
+export interface SwissBracketProps {
+  /**
+   * All registered participants. Must be supplied even when providing manual
+   * matches — used to initialise standings rows and validate pairings.
+   */
+  readonly participants: readonly TournamentParticipantInput[];
+  /**
+   * Manual round-by-round pairings. If omitted the bracket renders an empty
+   * schedule. Supply progressively as each round is confirmed.
+   */
+  readonly matches?: readonly SwissMatch[] | undefined;
+  /** Custom win/draw/loss point values. Defaults: win=1, draw=0.5, loss=0. */
+  readonly points?: SwissPointsRule | undefined;
+  /** Displayed at the top of the bracket. */
+  readonly title?: string | undefined;
+  /** Secondary label shown above the title (e.g. "Open Division"). */
+  readonly groupName?: string | undefined;
+  readonly appearance?: TournamentBracketAppearance | undefined;
+  readonly localization?: TournamentLocalizationOptions | undefined;
+  readonly isDarkMode?: boolean | undefined;
+  readonly compact?: boolean | undefined;
+}
+
+export const SwissBracket = React.memo<SwissBracketProps>(function SwissBracket({
+  appearance,
+  compact = false,
+  isDarkMode = false,
+  localization,
+  ...props
+}) {
+  return (
+    <BracketAppearanceProvider appearance={appearance} compact={compact} isDarkMode={isDarkMode}>
+      <BracketLocalizationProvider localization={localization}>
+        <SwissBracketContent {...props} compact={compact} />
+      </BracketLocalizationProvider>
+    </BracketAppearanceProvider>
+  );
+});
+
+SwissBracket.displayName = 'SwissBracket';
+
+// ── Internal ──────────────────────────────────────────────────────────────────
+
+function SwissBracketContent({
+  compact = false,
+  groupName,
+  matches = [],
+  participants,
+  points,
+  title = 'Swiss',
+}: Omit<SwissBracketProps, 'appearance' | 'isDarkMode' | 'localization'>) {
+  const { colors, frame, matchCard, typography } = useBracketAppearance();
+  const { uiLabels } = useBracketLocalization();
+  const tableFontSize = compact ? 12 : 14;
+
+  const standings = useMemo(
+    () => calculateSwissStandings(participants, matches, points),
+    [matches, participants, points]
+  );
+
+  const rounds = useMemo(() => groupSwissMatchesByRound(matches), [matches]);
+
+  const totalRounds = rounds.length > 0 ? rounds[rounds.length - 1]!.round : 0;
+
+  return (
+    <section
+      aria-label={groupName ? `${title}: ${groupName}` : title}
+      data-swiss-bracket
+      style={{
+        background: colors.SURFACE_BG,
+        border: `1px solid ${colors.HEADER_BORDER}`,
+        borderRadius: frame.borderRadius,
+        color: colors.FOREGROUND,
+        fontFamily: typography.bodyFontFamily,
+        padding: frame.contentPadding,
+      }}
+    >
+      <header style={{ marginBottom: compact ? 12 : 18 }}>
+        <p
+          style={{
+            color: colors.HEADER_MUTED,
+            fontSize: 11,
+            fontWeight: 800,
+            letterSpacing: '0.08em',
+            margin: 0,
+            textTransform: 'uppercase',
+          }}
+        >
+          {groupName ?? uiLabels.swiss}
+        </p>
+        <h2
+          style={{
+            color: colors.HEADER_TITLE,
+            fontSize: compact ? 18 : 24,
+            lineHeight: 1.2,
+            margin: '4px 0 0',
+          }}
+        >
+          {title}
+          {totalRounds > 0 ? (
+            <span
+              style={{
+                color: colors.HEADER_MUTED,
+                fontSize: compact ? 13 : 16,
+                fontWeight: 400,
+                marginLeft: 10,
+              }}
+            >
+              ({totalRounds} {uiLabels.round.toLowerCase()}
+              {totalRounds !== 1 ? 's' : ''})
+            </span>
+          ) : null}
+        </h2>
+      </header>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: compact ? 14 : 20,
+          gridTemplateColumns: compact ? '1fr' : 'minmax(340px, 0.9fr) minmax(340px, 1.1fr)',
+        }}
+      >
+        {/* Standings */}
+        <div>
+          <h3 style={{ fontSize: tableFontSize, margin: '0 0 8px' }}>{uiLabels.standings}</h3>
+          <div style={{ overflowX: 'auto' }}>
+            <table
+              aria-label={uiLabels.standings}
+              style={{
+                borderCollapse: 'collapse',
+                fontSize: tableFontSize,
+                minWidth: 420,
+                width: '100%',
+              }}
+            >
+              <thead>
+                <tr>
+                  {[
+                    { label: '#', numeric: true },
+                    { label: uiLabels.team, numeric: false },
+                    { label: uiLabels.played, numeric: true },
+                    { label: uiLabels.wins, numeric: true },
+                    { label: uiLabels.draws, numeric: true },
+                    { label: uiLabels.losses, numeric: true },
+                    { label: uiLabels.points, numeric: true },
+                    { label: uiLabels.buchholz, numeric: true },
+                    { label: uiLabels.sonnebornBerger, numeric: true },
+                  ].map(({ label, numeric }) => (
+                    <th
+                      key={label}
+                      scope="col"
+                      style={{
+                        borderBottom: `1px solid ${colors.BORDER}`,
+                        color: colors.LABEL_TEXT,
+                        padding: '8px 6px',
+                        textAlign: numeric ? 'right' : 'left',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {standings.map((standing, index) => (
+                  <tr key={standing.player.id ?? standing.player.name}>
+                    <td style={numericCellStyle(colors.BORDER)}>{index + 1}</td>
+                    <td
+                      style={{
+                        borderBottom: `1px solid ${colors.BORDER}`,
+                        padding: '8px 6px',
+                      }}
+                    >
+                      {standing.player.name}
+                    </td>
+                    <td style={numericCellStyle(colors.BORDER)}>{standing.played}</td>
+                    <td style={numericCellStyle(colors.BORDER)}>{standing.wins}</td>
+                    <td style={numericCellStyle(colors.BORDER)}>{standing.draws}</td>
+                    <td style={numericCellStyle(colors.BORDER)}>{standing.losses}</td>
+                    <td style={{ ...numericCellStyle(colors.BORDER), fontWeight: 800 }}>
+                      {formatPoints(standing.points)}
+                    </td>
+                    <td style={numericCellStyle(colors.BORDER)}>
+                      {formatPoints(standing.buchholz)}
+                    </td>
+                    <td style={numericCellStyle(colors.BORDER)}>
+                      {formatPoints(standing.sonnebornBerger)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Schedule */}
+        <div>
+          <h3 style={{ fontSize: tableFontSize, margin: '0 0 8px' }}>{uiLabels.schedule}</h3>
+          {rounds.length === 0 ? (
+            <p style={{ color: colors.MUTED_TEXT, fontSize: tableFontSize, margin: 0 }}>
+              No pairings yet.
+            </p>
+          ) : (
+            <div style={{ display: 'grid', gap: compact ? 10 : 14 }}>
+              {rounds.map((round) => (
+                <section key={round.round} aria-labelledby={`swiss-round-${round.round}`}>
+                  <h4
+                    id={`swiss-round-${round.round}`}
+                    style={{
+                      color: colors.LABEL_TEXT,
+                      fontSize: 12,
+                      letterSpacing: '0.06em',
+                      margin: '0 0 6px',
+                      textTransform: 'uppercase',
+                    }}
+                  >
+                    {uiLabels.round} {round.round}
+                  </h4>
+                  <div style={{ display: 'grid', gap: 8 }}>
+                    {round.matches.map((match) => (
+                      <SwissMatchCard
+                        key={match.id}
+                        match={match}
+                        borderRadius={matchCard.borderRadius}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Match card ────────────────────────────────────────────────────────────────
+
+function SwissMatchCard({
+  borderRadius,
+  match,
+}: {
+  readonly borderRadius: number;
+  readonly match: SwissMatch;
+}) {
+  const { colors, typography } = useBracketAppearance();
+  const localization = useBracketLocalization();
+  const [playerOne, playerTwo] = match.players;
+  const isCompleted = match.status === MatchStatus.Completed && match.scores;
+  const statusText = match.status
+    ? formatStatusLabel(match.status, localization)
+    : localization.uiLabels.upcoming;
+  const scoreText = isCompleted ? `${match.scores?.[0]} – ${match.scores?.[1]}` : statusText;
+
+  const scheduleText = getMatchScheduleText(
+    {
+      scheduledAt: match.scheduledAt,
+      timezone: undefined,
+      venue: match.venue,
+    },
+    localization
+  );
+
+  const [p1Score, p2Score] = match.scores ?? [];
+  const p1Won = isCompleted && p1Score !== undefined && p2Score !== undefined && p1Score > p2Score;
+  const p2Won = isCompleted && p2Score !== undefined && p1Score !== undefined && p2Score > p1Score;
+
+  return (
+    <article
+      aria-label={`${playerOne.name} versus ${playerTwo.name}, ${localization.uiLabels.round.toLowerCase()} ${match.round}, ${scoreText}${scheduleText ? `, ${localization.uiLabels.scheduled} ${scheduleText}` : ''}`}
+      style={{
+        alignItems: 'center',
+        background: colors.BASE_BG,
+        border: `1px solid ${colors.CARD_BORDER}`,
+        borderRadius,
+        display: 'grid',
+        gap: 10,
+        gridTemplateColumns: '1fr auto 1fr',
+        padding: '10px 12px',
+      }}
+    >
+      <span style={{ fontWeight: p1Won ? 700 : 400 }}>{playerOne.name}</span>
+      <strong
+        style={{
+          color: isCompleted ? colors.WINNING_SCORE : colors.MUTED_TEXT,
+          fontFamily: typography.scoreFontFamily,
+          fontSize: 13,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {scoreText}
+      </strong>
+      <span style={{ fontWeight: p2Won ? 700 : 400, textAlign: 'right' }}>{playerTwo.name}</span>
+      {scheduleText ? (
+        <small
+          style={{
+            color: colors.MUTED_TEXT,
+            fontSize: 11,
+            gridColumn: '1 / -1',
+            textAlign: 'center',
+          }}
+        >
+          {scheduleText}
+        </small>
+      ) : null}
+    </article>
+  );
+}
+
+// ── Utils ─────────────────────────────────────────────────────────────────────
+
+function numericCellStyle(borderColor: string): React.CSSProperties {
+  return {
+    borderBottom: `1px solid ${borderColor}`,
+    fontVariantNumeric: 'tabular-nums',
+    padding: '8px 6px',
+    textAlign: 'right',
+  };
+}
+
+/** Renders integers without decimals and floats with up to 1 decimal place. */
+function formatPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}

--- a/src/react-tournament-tree/src/components/__tests__/SwissBracket.test.tsx
+++ b/src/react-tournament-tree/src/components/__tests__/SwissBracket.test.tsx
@@ -1,0 +1,190 @@
+import { MatchStatus, type SwissMatch } from '@graph-render/types/tournament';
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SwissBracket } from '../SwissBracket';
+import { renderWithAppearance } from './testUtils';
+
+const participants = ['Alice', 'Bob', 'Carol', 'Dave'];
+const matches: readonly SwissMatch[] = [
+  {
+    id: 'r1-m1',
+    players: [{ name: 'Alice' }, { name: 'Bob' }],
+    round: 1,
+    scores: [1, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r1-m2',
+    players: [{ name: 'Carol' }, { name: 'Dave' }],
+    round: 1,
+    scores: [0, 0],
+    status: MatchStatus.Completed,
+  },
+  {
+    id: 'r2-m1',
+    players: [{ name: 'Alice' }, { name: 'Carol' }],
+    round: 2,
+    status: MatchStatus.Upcoming,
+  },
+];
+
+describe('SwissBracket', () => {
+  it('renders standings and schedule grouped by round', () => {
+    renderWithAppearance(
+      <SwissBracket
+        participants={participants}
+        matches={matches}
+        title="Open Swiss"
+        groupName="Division A"
+      />
+    );
+
+    expect(screen.getByRole('region', { name: /Open Swiss: Division A/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Standings' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Schedule' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Round 1' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Round 2' })).toBeInTheDocument();
+  });
+
+  it('shows standings sorted by points with tiebreaker columns', () => {
+    renderWithAppearance(<SwissBracket participants={participants} matches={matches} />);
+
+    const table = screen.getByRole('table', { name: 'Standings' });
+    const headers = within(table).getAllByRole('columnheader');
+    const headerTexts = headers.map((h) => h.textContent);
+
+    expect(headerTexts).toContain('Pts');
+    expect(headerTexts).toContain('BH');
+    expect(headerTexts).toContain('SB');
+
+    // Alice has 1 point; she should appear in row index 1 (after header row)
+    const rows = within(table).getAllByRole('row');
+    expect(within(rows[1]!).getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('shows rank numbers in standings', () => {
+    renderWithAppearance(<SwissBracket participants={participants} matches={matches} />);
+
+    const table = screen.getByRole('table', { name: 'Standings' });
+    const dataRows = within(table).getAllByRole('row').slice(1);
+    // first cell of each row is the rank number
+    expect(within(dataRows[0]!).getAllByRole('cell')[0]).toHaveTextContent('1');
+    expect(within(dataRows[1]!).getAllByRole('cell')[0]).toHaveTextContent('2');
+  });
+
+  it('displays 0.5 draw points correctly', () => {
+    renderWithAppearance(<SwissBracket participants={participants} matches={matches} />);
+
+    const table = screen.getByRole('table', { name: 'Standings' });
+    const rows = within(table).getAllByRole('row');
+    // Carol and Dave drew — 0.5 pts each; points column is index 6
+    const carolRow = rows.find((row) => within(row).queryByText('Carol'));
+    expect(carolRow).toBeDefined();
+    const carolCells = within(carolRow!).getAllByRole('cell');
+    expect(carolCells[6]).toHaveTextContent('0.5');
+  });
+
+  it('shows "No pairings yet" when matches are omitted', () => {
+    renderWithAppearance(<SwissBracket participants={participants} />);
+
+    expect(screen.getByText(/no pairings yet/i)).toBeInTheDocument();
+  });
+
+  it('shows round count in title area', () => {
+    renderWithAppearance(
+      <SwissBracket participants={participants} matches={matches} title="Championship" />
+    );
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Championship');
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('2 rounds');
+  });
+
+  it('localizes UI labels', () => {
+    renderWithAppearance(
+      <SwissBracket
+        participants={participants}
+        matches={matches}
+        localization={{
+          uiLabels: {
+            standings: 'Classement',
+            schedule: 'Planning',
+            round: 'Ronde',
+            buchholz: 'BH-FR',
+            sonnebornBerger: 'SB-FR',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Classement' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Planning' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Ronde 1' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'BH-FR' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'SB-FR' })).toBeInTheDocument();
+  });
+
+  it('renders match cards with winner name bold', () => {
+    renderWithAppearance(
+      <SwissBracket
+        participants={participants}
+        matches={[
+          {
+            id: 'r1-m1',
+            players: [{ name: 'Alice' }, { name: 'Bob' }],
+            round: 1,
+            scores: [1, 0],
+            status: MatchStatus.Completed,
+          },
+        ]}
+      />
+    );
+
+    // Alice should be bolded as winner
+    const aliceCells = screen.getAllByText('Alice');
+    const boldAlice = aliceCells.find((el) => el.style.fontWeight === '700');
+    expect(boldAlice).toBeDefined();
+  });
+
+  it('renders correctly with isDarkMode and compact props', () => {
+    renderWithAppearance(
+      <SwissBracket
+        participants={participants}
+        matches={matches}
+        isDarkMode
+        compact
+        title="Dark Compact"
+      />
+    );
+
+    expect(screen.getByRole('region', { name: /Dark Compact/i })).toBeInTheDocument();
+  });
+
+  it('renders scheduled match venue and date', () => {
+    const scheduledAt = '2026-07-01T14:00:00Z';
+    const expectedDate = new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+    }).format(new Date(scheduledAt));
+
+    renderWithAppearance(
+      <SwissBracket
+        participants={participants}
+        matches={[
+          {
+            id: 'r1-m1',
+            players: [{ name: 'Alice' }, { name: 'Bob' }],
+            round: 1,
+            scheduledAt,
+            status: MatchStatus.Upcoming,
+            venue: 'Board 1',
+          },
+        ]}
+        localization={{ locale: 'en-US', timeZone: 'UTC' }}
+      />
+    );
+
+    expect(screen.getByText(`${expectedDate} · Board 1`)).toBeInTheDocument();
+  });
+});

--- a/src/react-tournament-tree/src/index.ts
+++ b/src/react-tournament-tree/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { PlacementBracket, type PlacementBracketProps } from './components/PlacementBracket';
 export { RoundRobinBracket, type RoundRobinBracketProps } from './components/RoundRobinBracket';
 export { SquashNode } from './components/SquashNode';
+export { SwissBracket, type SwissBracketProps } from './components/SwissBracket';
 export { TournamentBracket } from './components/TournamentBracket';
 export {
   COMPACT_TOURNAMENT_CONFIG,
@@ -78,6 +79,7 @@ export {
   type BuildKnockoutFromGroupsOptions,
   calculateGroupAdvancers,
   calculateRoundRobinStandings,
+  calculateSwissStandings,
   correctMatchResult,
   type DoubleEliminationBracketOptions,
   type DoubleEliminationEdgeMeta,
@@ -91,6 +93,7 @@ export {
   groupPlacementMatchesByRound,
   groupPlacementMatchesByTier,
   groupRoundRobinMatchesByRound,
+  groupSwissMatchesByRound,
   type MatchResultUpdate,
   nextPowerOfTwo,
   type ParticipantCascadeChange,
@@ -105,6 +108,9 @@ export {
   type SingleEliminationBracketOptions,
   type SingleEliminationGraph,
   type SingleEliminationSeeding,
+  type SwissMatch,
+  type SwissPointsRule,
+  type SwissStanding,
   type TournamentParticipantInput,
 } from './utils/tournament';
 /* eslint-disable @typescript-eslint/no-deprecated -- legacy tournament aliases remain exported for backward compatibility */

--- a/src/react-tournament-tree/src/utils/tournament/__tests__/swiss.test.ts
+++ b/src/react-tournament-tree/src/utils/tournament/__tests__/swiss.test.ts
@@ -1,0 +1,297 @@
+import { MatchStatus, type SwissMatch } from '@graph-render/types/tournament';
+import { describe, expect, it } from 'vitest';
+
+import { calculateSwissStandings, groupSwissMatchesByRound } from '../swiss';
+
+describe('groupSwissMatchesByRound', () => {
+  it('groups matches by round, sorted ascending', () => {
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r2-m1',
+        players: [{ name: 'Alice' }, { name: 'Carol' }],
+        round: 2,
+        status: MatchStatus.Upcoming,
+      },
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        status: MatchStatus.Completed,
+        scores: [1, 0],
+      },
+      {
+        id: 'r1-m2',
+        players: [{ name: 'Carol' }, { name: 'Dave' }],
+        round: 1,
+        status: MatchStatus.Upcoming,
+      },
+    ];
+
+    const rounds = groupSwissMatchesByRound(matches);
+
+    expect(rounds).toHaveLength(2);
+    expect(rounds[0]?.round).toBe(1);
+    expect(rounds[0]?.matches).toHaveLength(2);
+    expect(rounds[1]?.round).toBe(2);
+    expect(rounds[1]?.matches).toHaveLength(1);
+  });
+
+  it('returns empty array for no matches', () => {
+    expect(groupSwissMatchesByRound([])).toHaveLength(0);
+  });
+
+  it('sorts matches within a round by id', () => {
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r1-m3',
+        players: [{ name: 'Carol' }, { name: 'Dave' }],
+        round: 1,
+        status: MatchStatus.Upcoming,
+      },
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        status: MatchStatus.Upcoming,
+      },
+    ];
+
+    const [round] = groupSwissMatchesByRound(matches);
+    expect(round?.matches[0]?.id).toBe('r1-m1');
+    expect(round?.matches[1]?.id).toBe('r1-m3');
+  });
+});
+
+// ── calculateSwissStandings ───────────────────────────────────────────────────
+
+describe('calculateSwissStandings', () => {
+  it('rejects fewer than 2 participants', () => {
+    expect(() => calculateSwissStandings(['Solo'], [])).toThrow(/at least two/);
+  });
+
+  it('rejects invalid participant (empty string)', () => {
+    expect(() => calculateSwissStandings(['Alice', ' '], [])).toThrow(/non-empty/);
+  });
+
+  it('rejects completed match referencing unknown participant', () => {
+    expect(() =>
+      calculateSwissStandings(
+        ['Alice', 'Bob'],
+        [
+          {
+            id: 'r1-m1',
+            players: [{ name: 'Alice' }, { name: 'Ghost' }],
+            round: 1,
+            scores: [1, 0],
+            status: MatchStatus.Completed,
+          },
+        ]
+      )
+    ).toThrow(/unknown participant/);
+  });
+
+  it('ignores upcoming and matches without scores', () => {
+    const standings = calculateSwissStandings(
+      ['Alice', 'Bob'],
+      [
+        {
+          id: 'r1-m1',
+          players: [{ name: 'Alice' }, { name: 'Bob' }],
+          round: 1,
+          status: MatchStatus.Upcoming,
+        },
+      ]
+    );
+
+    expect(standings).toHaveLength(2);
+    expect(standings.every((s) => s.played === 0 && s.points === 0)).toBe(true);
+  });
+
+  it('tallies wins, draws, losses and default Swiss points (1/0.5/0)', () => {
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+      {
+        id: 'r1-m2',
+        players: [{ name: 'Carol' }, { name: 'Dave' }],
+        round: 1,
+        scores: [0, 0],
+        status: MatchStatus.Completed,
+      },
+    ];
+
+    const standings = calculateSwissStandings(['Alice', 'Bob', 'Carol', 'Dave'], matches);
+
+    const alice = standings.find((s) => s.player.name === 'Alice')!;
+    const bob = standings.find((s) => s.player.name === 'Bob')!;
+    const carol = standings.find((s) => s.player.name === 'Carol')!;
+
+    expect(alice).toMatchObject({ wins: 1, draws: 0, losses: 0, played: 1, points: 1 });
+    expect(bob).toMatchObject({ wins: 0, draws: 0, losses: 1, played: 1, points: 0 });
+    expect(carol).toMatchObject({ wins: 0, draws: 1, losses: 0, played: 1, points: 0.5 });
+  });
+
+  it('supports custom point values', () => {
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        scores: [1, 1],
+        status: MatchStatus.Completed,
+      },
+    ];
+
+    const standings = calculateSwissStandings(['Alice', 'Bob', 'Carol', 'Dave'], matches, {
+      draw: 1,
+      loss: 0,
+      win: 3,
+    });
+
+    const alice = standings.find((s) => s.player.name === 'Alice')!;
+    expect(alice.points).toBe(1);
+  });
+
+  it('sorts by points desc, then buchholz desc, then sonnebornBerger desc', () => {
+    // Round 1: Alice beats Bob; Carol beats Dave
+    // Round 2: Alice beats Carol; Bob beats Dave
+    // After 2 rounds: Alice=2, Carol=1, Bob=1, Dave=0
+    // Alice's Buchholz = Bob.pts + Carol.pts = 1 + 1 = 2
+    // Carol's Buchholz = Alice.pts + Dave.pts = 2 + 0 = 2
+    // Bob's Buchholz   = Alice.pts + Dave.pts = 2 + 0 = 2
+    // Carol SB = 0 (lost to Alice) + 0 (won over Dave, Dave.pts=0) = 0
+    // Bob SB = 0 (lost to Alice) + 0 (won over Dave, Dave.pts=0) = 0
+    // Carol and Bob have same points/BH/SB → alphabetical
+
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+      {
+        id: 'r1-m2',
+        players: [{ name: 'Carol' }, { name: 'Dave' }],
+        round: 1,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+      {
+        id: 'r2-m1',
+        players: [{ name: 'Alice' }, { name: 'Carol' }],
+        round: 2,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+      {
+        id: 'r2-m2',
+        players: [{ name: 'Bob' }, { name: 'Dave' }],
+        round: 2,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+    ];
+
+    const standings = calculateSwissStandings(['Alice', 'Bob', 'Carol', 'Dave'], matches);
+
+    expect(standings[0]?.player.name).toBe('Alice');
+    expect(standings[0]?.points).toBe(2);
+    // Bob and Carol tied on points; check they both appear in positions 1-2
+    const names12 = [standings[1]?.player.name, standings[2]?.player.name].sort();
+    expect(names12).toEqual(['Bob', 'Carol']);
+    expect(standings[3]?.player.name).toBe('Dave');
+  });
+
+  it('renders all 5 rounds correctly for a 5-round Swiss event', () => {
+    // 6 players over 5 rounds, manual pairings
+    const sixParticipants = ['A', 'B', 'C', 'D', 'E', 'F'];
+    const matches: SwissMatch[] = [];
+    for (let r = 1; r <= 5; r += 1) {
+      matches.push(
+        {
+          id: `r${r}-m1`,
+          players: [{ name: 'A' }, { name: 'B' }],
+          round: r,
+          scores: [1, 0],
+          status: MatchStatus.Completed,
+        },
+        {
+          id: `r${r}-m2`,
+          players: [{ name: 'C' }, { name: 'D' }],
+          round: r,
+          scores: [0, 0],
+          status: MatchStatus.Completed,
+        },
+        {
+          id: `r${r}-m3`,
+          players: [{ name: 'E' }, { name: 'F' }],
+          round: r,
+          scores: [0, 1],
+          status: MatchStatus.Completed,
+        }
+      );
+    }
+
+    const standings = calculateSwissStandings(sixParticipants, matches);
+    const rounds = groupSwissMatchesByRound(matches);
+
+    expect(rounds).toHaveLength(5);
+    expect(standings).toHaveLength(6);
+    // A wins all 5 rounds
+    const aStanding = standings.find((s) => s.player.name === 'A')!;
+    expect(aStanding.wins).toBe(5);
+    expect(aStanding.points).toBe(5);
+    // F wins all 5 rounds
+    const fStanding = standings.find((s) => s.player.name === 'F')!;
+    expect(fStanding.wins).toBe(5);
+  });
+
+  it('computes Buchholz correctly', () => {
+    // Alice beats Bob (Bob ends with 0 pts), Carol beats Dave (Dave ends with 0 pts)
+    // Alice's Buchholz = Bob.pts = 0
+    // Carol's Buchholz = Dave.pts = 0
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+      {
+        id: 'r1-m2',
+        players: [{ name: 'Carol' }, { name: 'Dave' }],
+        round: 1,
+        scores: [1, 0],
+        status: MatchStatus.Completed,
+      },
+    ];
+
+    const standings = calculateSwissStandings(['Alice', 'Bob', 'Carol', 'Dave'], matches);
+    const alice = standings.find((s) => s.player.name === 'Alice')!;
+    expect(alice.buchholz).toBe(0); // Bob has 0 pts
+    expect(alice.sonnebornBerger).toBe(0); // Bob has 0 pts
+  });
+
+  it('formats standings for display with 0.5 draw points', () => {
+    const matches: readonly SwissMatch[] = [
+      {
+        id: 'r1-m1',
+        players: [{ name: 'Alice' }, { name: 'Bob' }],
+        round: 1,
+        scores: [0, 0],
+        status: MatchStatus.Completed,
+      },
+    ];
+    const standings = calculateSwissStandings(['Alice', 'Bob'], matches);
+    expect(standings[0]?.points).toBe(0.5);
+    expect(standings[1]?.points).toBe(0.5);
+  });
+});

--- a/src/react-tournament-tree/src/utils/tournament/index.ts
+++ b/src/react-tournament-tree/src/utils/tournament/index.ts
@@ -43,3 +43,10 @@ export {
   type SingleEliminationSeeding,
   type TournamentParticipantInput,
 } from './singleElimination';
+export {
+  calculateSwissStandings,
+  groupSwissMatchesByRound,
+  type SwissMatch,
+  type SwissPointsRule,
+  type SwissStanding,
+} from './swiss';

--- a/src/react-tournament-tree/src/utils/tournament/swiss.ts
+++ b/src/react-tournament-tree/src/utils/tournament/swiss.ts
@@ -1,0 +1,213 @@
+import {
+  type MatchPlayer,
+  MatchStatus,
+  type SwissMatch,
+  type SwissPointsRule,
+  type SwissStanding,
+} from '@graph-render/types/tournament';
+
+import type { TournamentParticipantInput } from './singleElimination';
+
+export type { SwissMatch, SwissPointsRule, SwissStanding } from '@graph-render/types/tournament';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const normalizeParticipant = (
+  participant: TournamentParticipantInput,
+  index: number
+): MatchPlayer => {
+  if (typeof participant === 'string') {
+    const name = participant.trim();
+    if (!name) throw new TypeError(`participants[${index}] must be a non-empty string.`);
+    return { name };
+  }
+  if (!participant || typeof participant !== 'object') {
+    throw new TypeError(`participants[${index}] must be a string or MatchPlayer object.`);
+  }
+  if (typeof participant.name !== 'string' || !participant.name.trim()) {
+    throw new TypeError(`participants[${index}].name must be a non-empty string.`);
+  }
+  return { ...participant, name: participant.name.trim() };
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+interface ResolvedSwissPointsRule {
+  readonly win: number;
+  readonly draw: number;
+  readonly loss: number;
+}
+
+const DEFAULT_POINTS: ResolvedSwissPointsRule = { draw: 0.5, loss: 0, win: 1 };
+
+const resolvePoints = (points: SwissPointsRule | undefined): ResolvedSwissPointsRule => ({
+  draw: points?.draw ?? DEFAULT_POINTS.draw,
+  loss: points?.loss ?? DEFAULT_POINTS.loss,
+  win: points?.win ?? DEFAULT_POINTS.win,
+});
+
+const playerKey = (player: { readonly id?: string | undefined; name: string }): string =>
+  (player.id?.trim() || player.name.trim()).toLocaleLowerCase();
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Groups Swiss matches by round number, sorted ascending.
+ */
+export function groupSwissMatchesByRound(
+  matches: readonly SwissMatch[]
+): ReadonlyArray<{ readonly round: number; readonly matches: readonly SwissMatch[] }> {
+  const grouped = new Map<number, SwissMatch[]>();
+  for (const match of matches) {
+    const group = grouped.get(match.round) ?? [];
+    group.push(match);
+    grouped.set(match.round, group);
+  }
+
+  return [...grouped.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([round, roundMatches]) => ({
+      matches: [...roundMatches].sort((a, b) => a.id.localeCompare(b.id)),
+      round,
+    }));
+}
+
+/**
+ * Computes Swiss-system standings from a participant list and completed matches.
+ *
+ * Standings are sorted by:
+ *   1. Points (descending)
+ *   2. Buchholz (sum of opponents' points, descending)
+ *   3. Sonneborn-Berger (sum of defeated/drawn opponents' points, descending)
+ *   4. Name (ascending, for deterministic output)
+ *
+ * @param participantsInput - All registered participants.
+ * @param matches           - All pairings, including upcoming ones.
+ * @param points            - Custom point values. Defaults: win=1, draw=0.5, loss=0.
+ */
+export function calculateSwissStandings(
+  participantsInput: readonly TournamentParticipantInput[],
+  matches: readonly SwissMatch[],
+  points?: SwissPointsRule
+): readonly SwissStanding[] {
+  if (participantsInput.length < 2) {
+    throw new RangeError('Swiss tournaments require at least two participants.');
+  }
+
+  const participants = participantsInput.map((p, i) => normalizeParticipant(p, i));
+  const resolved = resolvePoints(points);
+
+  // Phase 1: tally wins/draws/losses/points for each participant.
+  interface MutableStanding {
+    wins: number;
+    draws: number;
+    losses: number;
+    played: number;
+    points: number;
+  }
+
+  const tally = new Map<string, MutableStanding>(
+    participants.map((p) => [playerKey(p), { draws: 0, losses: 0, played: 0, points: 0, wins: 0 }])
+  );
+
+  for (const match of matches) {
+    if (match.status !== MatchStatus.Completed || !match.scores) continue;
+
+    const [p1, p2] = match.players;
+    const [s1, s2] = match.scores;
+
+    const k1 = playerKey(p1);
+    const k2 = playerKey(p2);
+
+    const t1 = tally.get(k1);
+    const t2 = tally.get(k2);
+
+    if (!t1) {
+      throw new RangeError(
+        `Swiss match "${match.id}" references unknown participant "${p1.name}".`
+      );
+    }
+    if (!t2) {
+      throw new RangeError(
+        `Swiss match "${match.id}" references unknown participant "${p2.name}".`
+      );
+    }
+
+    if (s1 > s2) {
+      t1.wins += 1;
+      t1.points += resolved.win;
+      t2.losses += 1;
+      t2.points += resolved.loss;
+    } else if (s2 > s1) {
+      t2.wins += 1;
+      t2.points += resolved.win;
+      t1.losses += 1;
+      t1.points += resolved.loss;
+    } else {
+      t1.draws += 1;
+      t1.points += resolved.draw;
+      t2.draws += 1;
+      t2.points += resolved.draw;
+    }
+
+    t1.played += 1;
+    t2.played += 1;
+  }
+
+  // Phase 2: compute Buchholz and Sonneborn-Berger using tallied points.
+  return participants
+    .map((player) => {
+      const key = playerKey(player);
+      const standing = tally.get(key)!;
+
+      let buchholz = 0;
+      let sonnebornBerger = 0;
+
+      for (const match of matches) {
+        if (match.status !== MatchStatus.Completed || !match.scores) continue;
+
+        const [p1, p2] = match.players;
+        const [s1, s2] = match.scores;
+
+        const k1 = playerKey(p1);
+        const k2 = playerKey(p2);
+
+        let opponentKey: string | undefined;
+        let outcomeForPlayer: 'win' | 'draw' | 'loss' | undefined;
+
+        if (k1 === key) {
+          opponentKey = k2;
+          outcomeForPlayer = s1 > s2 ? 'win' : s1 < s2 ? 'loss' : 'draw';
+        } else if (k2 === key) {
+          opponentKey = k1;
+          outcomeForPlayer = s2 > s1 ? 'win' : s2 < s1 ? 'loss' : 'draw';
+        }
+
+        if (opponentKey && outcomeForPlayer) {
+          const opponentTally = tally.get(opponentKey);
+          if (opponentTally) {
+            buchholz += opponentTally.points;
+            if (outcomeForPlayer === 'win') sonnebornBerger += opponentTally.points;
+            else if (outcomeForPlayer === 'draw') sonnebornBerger += opponentTally.points / 2;
+          }
+        }
+      }
+
+      return {
+        buchholz,
+        draws: standing.draws,
+        losses: standing.losses,
+        played: standing.played,
+        player,
+        points: standing.points,
+        sonnebornBerger,
+        wins: standing.wins,
+      } satisfies SwissStanding;
+    })
+    .sort((a, b) => {
+      if (b.points !== a.points) return b.points - a.points;
+      if (b.buchholz !== a.buchholz) return b.buchholz - a.buchholz;
+      if (b.sonnebornBerger !== a.sonnebornBerger) return b.sonnebornBerger - a.sonnebornBerger;
+      return a.player.name.localeCompare(b.player.name);
+    });
+}

--- a/src/types/src/tournament.ts
+++ b/src/types/src/tournament.ts
@@ -90,6 +90,52 @@ export interface GroupAdvancementRule {
   readonly manualAdvancers?: readonly MatchPlayer[] | undefined;
 }
 
+// ── Swiss System ────────────────────────────────────────────────────────────
+
+/**
+ * Configurable win/draw/loss point values for Swiss standings.
+ * Defaults: win=1, draw=0.5, loss=0.
+ */
+export interface SwissPointsRule {
+  readonly win?: number | undefined;
+  readonly draw?: number | undefined;
+  readonly loss?: number | undefined;
+}
+
+/**
+ * A single pairing in a Swiss-system tournament.
+ * Pairings are manual — supply them round by round.
+ */
+export interface SwissMatch {
+  readonly id: string;
+  readonly round: number;
+  readonly players: readonly [MatchPlayer, MatchPlayer];
+  /** Final scores for each player. Required when status is Completed. */
+  readonly scores?: readonly [number, number] | undefined;
+  readonly status?: MatchStatus | `${MatchStatus}` | undefined;
+  readonly scheduledAt?: string | undefined;
+  readonly venue?: string | undefined;
+}
+
+/**
+ * Standing entry for a Swiss-system tournament.
+ * Includes Buchholz and Sonneborn-Berger tiebreakers.
+ */
+export interface SwissStanding {
+  readonly player: MatchPlayer;
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  /** Buchholz: sum of each opponent's total points (strength-of-schedule). */
+  readonly buchholz: number;
+  /** Sonneborn-Berger: sum of points of defeated opponents + half of drawn opponents' points. */
+  readonly sonnebornBerger: number;
+}
+
+// ── Elimination ─────────────────────────────────────────────────────────────
+
 export type EliminationFormat = 'double' | 'single';
 
 // --- Placement matches ---


### PR DESCRIPTION
- Add SwissPointsRule, SwissMatch, SwissStanding types to @graph-render/types
- Add calculateSwissStandings() with Buchholz and Sonneborn-Berger tiebreakers
- Add groupSwissMatchesByRound() utility
- Add SwissBracket component with standings table and round pairings
- Add buchholz, sonnebornBerger, swiss i18n labels
- Add 10 unit tests for Swiss utilities
- Add 10 component tests for SwissBracket
- Add 5 Storybook stories (FiveRounds, CustomPoints, NoMatchesYet, DarkMode, Compact)