### PR TITLE
fix(types): verify automatic npm publish pipeline end-to-end

### DIFF
--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -8,4 +8,4 @@ export type * from './rendering';
 export * from './routing';
 export type * from './svg';
 export type * from './viewport';
-// no-op: verifying npm publish pipeline
+// no-op: verifying automatic npm publish pipeline end-to-end


### PR DESCRIPTION
Trivial no-op change to trigger a real patch release via semantic-release and confirm it publishes to npm automatically now that NPM_TOKEN is a valid automation token.